### PR TITLE
chore(deps): upgrade homeassistant and mealie to app-template v5.0.1

### DIFF
--- a/cluster/home/homeassistant/helmrelease.yaml
+++ b/cluster/home/homeassistant/helmrelease.yaml
@@ -7,14 +7,14 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.0.1
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
         namespace: flux-system
   interval: 30m
   maxHistory: 3
-  # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.0.1/charts/other/app-template/values.schema.json
+  # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/values.schema.json
   values:
     controllers:
       app:

--- a/cluster/home/mealie/app/helmrelease.yaml
+++ b/cluster/home/mealie/app/helmrelease.yaml
@@ -7,13 +7,13 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.0.1
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
         namespace: flux-system
   maxHistory: 3
-  # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-4.0.1/charts/other/app-template/values.schema.json
+  # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/values.schema.json
   values:
     controllers:
       main:


### PR DESCRIPTION
## Summary

- Bumps `homeassistant` from bjw-s app-template `4.0.1` → `5.0.1`
- Bumps `mealie` from bjw-s app-template `4.0.1` → `5.0.1`
- Updates `yaml-language-server` schema comment URLs to match the new version in both files

Both charts were already on a v4-compatible schema which is valid in v5 with no structural changes. No Deployment recreation needed — these are smooth rolling updates.

## Test plan

- [ ] Flux reconciles both HelmReleases successfully (`kubectl get helmrelease -n home home-assistant mealie`)
- [ ] Both pods come up Running
- [ ] `ha.internal.wat.sn` and `ha.wat.sn` load in browser
- [ ] `mealie.internal.wat.sn` and `mealie.wat.sn` load and OIDC login works