### PR TITLE
fix: remove stray namespace override from cluster/home kustomization

### DIFF
--- a/cluster/home/kustomization.yaml
+++ b/cluster/home/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: planka
 resources:
 - planka
 - memos


### PR DESCRIPTION
## Summary

- Removes `namespace: planka` from `cluster/home/kustomization.yaml`

## What broke and why

The top-level `cluster/home/kustomization.yaml` had `namespace: planka` set, which kustomize applies as a namespace transformation to **all** child resources including those from sub-kustomizations. When `memos` and `homeassistant` were later added as siblings of `planka`, their own `namespace:` declarations were overridden, causing both to resolve to `planka`. This produced an ID conflict that failed the kustomize build:

```
namespace transformation produces ID conflict: [planka (from planka), planka (from memos)]
```

This has been blocking the `flux-system` kustomization from applying **any** changes to `cluster/home` — including the recent app-template v5.0.1 upgrades for homeassistant and mealie.

## Fix

Remove `namespace: planka` from the parent kustomization. Each child kustomization (`planka/`, `memos/`, `homeassistant/`) already declares its own `namespace:` correctly.

## Test plan

- [ ] `flux reconcile kustomization flux-system` succeeds without build errors
- [ ] `kubectl get helmrelease -n home-assistant home-assistant` shows `app-template@5.0.1`
- [ ] `kubectl get helmrelease -n mealie mealie` shows `app-template@5.0.1`
- [ ] Planka, memos, and homeassistant pods remain healthy