### PR TITLE
fix: enable CRD upgrades for external-secrets HelmRelease

### DIFF
--- a/cluster/external-secrets/app/helmrelease.yaml
+++ b/cluster/external-secrets/app/helmrelease.yaml
@@ -14,6 +14,8 @@ spec:
         kind: HelmRepository
         name: external-secrets-charts
         namespace: flux-system
+  upgrade:
+    crds: CreateReplace
   values:
     installCRDs: true
     serviceMonitor:


### PR DESCRIPTION
## Summary

Adds `spec.upgrade.crds: CreateReplace` to the external-secrets HelmRelease.

## Problem

The cluster's external-secrets CRDs are stale — they only serve `v1alpha1` and `v1beta1`, but external-secrets v0.10+ promotes the API to `v1`. Manifests in this repo correctly use `external-secrets.io/v1` per the [current docs](https://external-secrets.io/latest/api/clusterexternalsecret/), but Flux's dry-run validation fails because the in-cluster CRDs don't know about `v1` yet:

```
ClusterExternalSecret/gcr-artifact-registry dry-run failed: no matches for kind "ClusterExternalSecret" in version "external-secrets.io/v1"
```

This is a well-known Helm limitation: CRDs are installed on first deploy but **never upgraded** by `helm upgrade`. The external-secrets operator was upgraded to v0.10.3 but the CRDs were left at their original (pre-v1) state.

## Fix

`spec.upgrade.crds: CreateReplace` tells the Flux Helm controller to replace CRDs during the next upgrade reconciliation, bringing them up to date with what the v0.10.3 chart ships. This is safe here because `v1` is a superset of `v1beta1` — existing stored resources remain valid.

## Test plan

- [ ] After merge + reconcile: `kubectl get crd externalsecrets.external-secrets.io -o jsonpath='{.spec.versions[*].name}'` includes `v1`
- [ ] `flux get kustomization flux-system` shows `Ready: True`
- [ ] `kubectl get helmrelease -n home-assistant home-assistant` shows `app-template@5.0.1`
- [ ] `kubectl get externalsecrets -A` all healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)