### PR TITLE
chore(deps): upgrade external-secrets from 0.10.3 to 2.6.0

### DIFF
--- a/cluster/external-secrets/app/helmrelease.yaml
+++ b/cluster/external-secrets/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: external-secrets
-      version: 0.10.3
+      version: 2.6.0
       sourceRef:
         kind: HelmRepository
         name: external-secrets-charts
@@ -18,6 +18,8 @@ spec:
     crds: CreateReplace
   values:
     installCRDs: true
+    crds:
+      serveV1Beta1: true
     serviceMonitor:
       enabled: true
       interval: 1m


### PR DESCRIPTION
## Summary

- Upgrades external-secrets Helm chart from `0.10.3` (app `v0.10.3`) to `2.6.0` (app `v2.5.0`)
- Adds `crds.serveV1Beta1: true` temporarily during the transition
- The existing `upgrade.crds: CreateReplace` (#1974) will update the stale CRDs to serve `v1`

## Why

The cluster CRDs only serve `v1alpha1` and `v1beta1`. All manifests in this repo correctly use `external-secrets.io/v1` (the GA API introduced in v1.0.0), but Flux dry-run validation fails because the installed version predates `v1`. Upgrading to `2.6.0` brings the CRDs in line with what the manifests expect.

## Migration notes

- All current values (`installCRDs`, `serviceMonitor` config) are compatible with `2.6.0` — no structural changes needed
- `crds.serveV1Beta1: true` is set so existing cluster resources (stored under `v1beta1`) continue to work while Flux reconciles everything to `v1`. This can be removed in a follow-up once all ExternalSecrets show healthy under `v1`.
- `v1beta1` is deprecated and scheduled for removal upstream on May 1, 2026

## Test plan

- [ ] `kubectl get helmrelease -n external-secrets external-secrets` shows `Ready: True` with chart `2.6.0`
- [ ] `kubectl get crd externalsecrets.external-secrets.io -o jsonpath='{.spec.versions[*].name}'` includes `v1`
- [ ] `kubectl get externalsecrets -A` — all secrets syncing
- [ ] `kubectl get clustersecretstore` — 1password store healthy
- [ ] `flux get kustomization flux-system` — `Ready: True` (no more dry-run failures)
- [ ] `kubectl get helmrelease -n home-assistant home-assistant` shows `app-template@5.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)