### PR TITLE
fix: add mealie to cluster/home kustomization

### DIFF
--- a/cluster/home/kustomization.yaml
+++ b/cluster/home/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - planka
 - memos
 - homeassistant
+- mealie


### PR DESCRIPTION
## Summary

Adds `mealie` to the resources list in `cluster/home/kustomization.yaml`.

## What broke and why

`mealie` has its own kustomization directory (`cluster/home/mealie/`) but was never added to the parent `cluster/home/kustomization.yaml`. This meant Flux was never applying changes to any mealie resources from git — the mealie HelmRelease was stuck at `app-template@4.0.1` despite the upgrade to `5.0.1` being merged in #1971.

This is the same class of issue as the `namespace: planka` bug (#1972) — the mealie directory was likely added to the repo but the parent kustomization was never updated to include it.

## Test plan

- [ ] After merge + reconcile: `kubectl get helmrelease -n mealie mealie` shows `app-template@5.0.1`
- [ ] Mealie pod remains healthy: `kubectl get pods -n mealie`
- [ ] `mealie.wat.sn` loads and OIDC login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)