### PR TITLE
chore(deps): upgrade memos, onepassword-connect, wishly to app-template v5.0.1

### DIFF
--- a/cluster/external-secrets/stores/1password/helmrelease.yaml
+++ b/cluster/external-secrets/stores/1password/helmrelease.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/values.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 3.0.4
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
@@ -51,7 +51,6 @@ spec:
             port: *apiPort
     ingress:
       api:
-        enabled: true
         className: nginx
         annotations:
           cert-manager.io/cluster-issuer: "letsencrypt-prod"

--- a/cluster/home/memos/app/helmrelease.yaml
+++ b/cluster/home/memos/app/helmrelease.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/values.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 3.0.4
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
@@ -17,7 +17,7 @@ spec:
     controllers:
       main:
         containers:
-          main:
+          app:
             image:
               repository: neosmemo/memos
               tag: 0.25.1@sha256:f1faf27fb60aff4df13fc2c6017baa7b6f8ea684dc9a9bff6f212a01d2efe108
@@ -38,7 +38,6 @@ spec:
             port: *apiPort
     ingress:
       main:
-        enabled: true
         className: nginx
         annotations:
           # proxy-body-size is set to 0 to remove the body limit on file uploads
@@ -64,10 +63,8 @@ spec:
             secretName: memos-cert
     persistence:
       resources:
-        enabled: true
-        type: persistentVolumeClaim
         existingClaim: memos-resources
         advancedMounts:
           main:
-            main:
+            app:
               - path: /var/opt/memos

--- a/cluster/wishly/prod/app/helmrelease.yaml
+++ b/cluster/wishly/prod/app/helmrelease.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2beta2.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/values.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 3.0.4
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
@@ -16,7 +16,7 @@ spec:
   values:
     defaultPodOptions:
       imagePullSecrets:
-        - name: artifact-registry-creds      
+        - name: artifact-registry-creds
     controllers:
       main:
         containers:
@@ -43,7 +43,6 @@ spec:
             port: *apiPort
     ingress:
       main:
-        enabled: true
         className: nginx
         annotations:
           cert-manager.io/cluster-issuer: "letsencrypt-prod"


### PR DESCRIPTION
Migrates three v3.0.4 app-template HelmReleases to v5.0.1.

## Changes

- Version bump `3.0.4` → `5.0.1`
- Schema comment updated to versioned `bjw-s-labs` URL (`values.schema.json`)
- Dropped `enabled: true` from ingress (not needed in v5)
- **memos**: container `main` → `app`, dropped `enabled`/`type: persistentVolumeClaim` from persistence, updated `advancedMounts` key
- **onepassword-connect** / **wishly**: containers already named; only version + schema + ingress cleanup needed