### PR TITLE
fix: force upgrade memos, onepassword-connect, wishly to recreate immutable selector

### DIFF
--- a/cluster/external-secrets/stores/1password/helmrelease.yaml
+++ b/cluster/external-secrets/stores/1password/helmrelease.yaml
@@ -5,6 +5,8 @@ metadata:
   name: &app onepassword-connect
 spec:
   interval: 30m
+  upgrade:
+    force: true
   chart:
     spec:
       chart: app-template

--- a/cluster/home/memos/app/helmrelease.yaml
+++ b/cluster/home/memos/app/helmrelease.yaml
@@ -5,6 +5,8 @@ metadata:
   name: &app memos
 spec:
   interval: 30m
+  upgrade:
+    force: true
   chart:
     spec:
       chart: app-template

--- a/cluster/wishly/prod/app/helmrelease.yaml
+++ b/cluster/wishly/prod/app/helmrelease.yaml
@@ -5,6 +5,8 @@ metadata:
   name: &app wishly
 spec:
   interval: 30m
+  upgrade:
+    force: true
   chart:
     spec:
       chart: app-template


### PR DESCRIPTION
app-template v5 added `app.kubernetes.io/controller` to Deployment label selectors. Since `spec.selector` is immutable in Kubernetes, the in-place upgrade from v3 fails with "field is immutable".

Adds `spec.upgrade.force: true` to each HelmRelease so Flux passes `--force` to Helm, which deletes and recreates the Deployment instead of patching it. Brief downtime expected for each app during reconciliation.