### PR TITLE
chore(deps): upgrade jellyfin, satisfactory to app-template v5.0.1

### DIFF
--- a/cluster/external/satisfactory/helmrelease.yaml
+++ b/cluster/external/satisfactory/helmrelease.yaml
@@ -8,46 +8,51 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
         namespace: flux-system
   maxHistory: 3
+  upgrade:
+    force: true
+  # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/values.schema.json
   values:
-    controller:
-      type: statefulset
-      replicas: 0
-
-    image:
-      repository: ghcr.io/wolveix/satisfactory-server/satisfactory-server
-      tag: v1.6.0@sha256:e36d95f12a90b9363fc1a3836041f4b35156399a78779a1dc89c827b93218bb7
+    controllers:
+      main:
+        type: StatefulSet
+        replicas: 0
+        containers:
+          app:
+            image:
+              repository: ghcr.io/wolveix/satisfactory-server/satisfactory-server
+              tag: v1.6.0@sha256:e36d95f12a90b9363fc1a3836041f4b35156399a78779a1dc89c827b93218bb7
+            probes:
+              startup:
+                enabled: false
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+            resources:
+              requests:
+                memory: 12G
     service:
       main:
+        controller: main
         type: LoadBalancer
         ports:
           http:
             port: 7777
             protocol: UDP
           query:
-            primary: false
             port: 15777
             protocol: UDP
           beacon:
-            primary: false
             port: 15000
             protocol: UDP
     persistence:
       config:
-        enabled: true
         existingClaim: satisfactory-data
-    probes:
-      startup:
-        enabled: false
-      liveness:
-        enabled: false
-      readiness:
-        enabled: false
-    resources:
-      requests:
-        memory: 12G
+        globalMounts:
+          - path: /config

--- a/cluster/media/jellyfin/helmrelease.yaml
+++ b/cluster/media/jellyfin/helmrelease.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/values.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -8,61 +9,72 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 1.5.1
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
         namespace: flux-system
   interval: 30m
+  upgrade:
+    force: true
   values:
-    image:
-      repository: jellyfin/jellyfin
-      tag: 10.11.10@sha256:f66273e014b307e4ac46778845ebc1e9ee24b2e57c1fc17d5ec5ac3015649bfa
-    env:
-      DOTNET_SYSTEM_IO_DISABLEFILELOCKING: "true"
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 568
+        runAsGroup: 568
+        fsGroup: 568
+        fsGroupChangePolicy: "OnRootMismatch"
+        supplementalGroups:
+          - 44
+          - 109
+          - 65539
+    controllers:
+      main:
+        containers:
+          app:
+            image:
+              repository: jellyfin/jellyfin
+              tag: 10.11.10@sha256:f66273e014b307e4ac46778845ebc1e9ee24b2e57c1fc17d5ec5ac3015649bfa
+            env:
+              DOTNET_SYSTEM_IO_DISABLEFILELOCKING: "true"
     service:
       main:
+        controller: main
         type: LoadBalancer
         externalTrafficPolicy: Local
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: media.internal.wat.sn.
         ports:
           http:
             port: 8096
-        annotations:
-          external-dns.alpha.kubernetes.io/hostname: media.internal.wat.sn.
     ingress:
       main:
-        enabled: true
-        ingressClassName: nginx
+        className: nginx
+        annotations:
+          cert-manager.io/cluster-issuer: "letsencrypt-prod"
         hosts:
           - host: watch.internal.wat.sn
             paths:
               - path: /
-                pathType: Prefix
+                service:
+                  identifier: main
+                  port: http
         tls:
           - hosts:
               - watch.internal.wat.sn
             secretName: jellfyin-ingress-cert
-        annotations:
-          cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    podSecurityContext:
-      runAsUser: 568
-      runAsGroup: 568
-      fsGroup: 568
-      fsGroupChangePolicy: "OnRootMismatch"
-      supplementalGroups:
-        - 44
-        - 109
-        - 65539
     persistence:
       config:
-        enabled: true
         existingClaim: jellyfin-config
+        globalMounts:
+          - path: /config
       media:
-        enabled: true
-        mountPath: /storage/media
-        path: /mnt/root/media
+        type: nfs
         server: 10.0.40.50
-        type: nfs 
+        path: /mnt/root/media
+        globalMounts:
+          - path: /storage/media
       transcode:
-        enabled: true
         type: emptyDir
+        globalMounts:
+          - path: /transcode


### PR DESCRIPTION
Full rewrite from app-template v1.5.1 → v5.0.1.

## Per-app changes

### Both
- `image:` (top-level) → `controllers.main.containers.app.image:`
- `podSecurityContext:` → `defaultPodOptions.securityContext:`
- `env:` → nested under container
- `ingressClassName:` → `className:`
- Ingress paths now include `service: {identifier, port}`
- `upgrade.force: true` added to handle immutable Deployment/StatefulSet selector change

### jellyfin
- `service.main.annotations` preserved at service level (external-dns hostname)
- `externalTrafficPolicy: Local` preserved on LoadBalancer service
- Persistence: `config` → `globalMounts: [{path: /config}]`, NFS `media` restructured, `transcode` emptyDir now has explicit `globalMounts: [{path: /transcode}]`
- Three supplementalGroups (44, 109, 65539) preserved for hardware transcoding

### satisfactory
- `controller.type: statefulset` → `controllers.main.type: StatefulSet`
- `replicas: 0` preserved
- `probes` (startup/liveness/readiness all disabled) moved under container
- `resources.requests.memory: 12G` moved under container
- UDP LoadBalancer ports preserved; `primary: false` dropped (not a v5 concept)
- Persistence: `config` → `globalMounts: [{path: /config}]`

## Post-merge steps
Deployments/StatefulSets will need manual deletion + suspend/resume (same pattern as the v3→v5 batch).