### PR TITLE
fix: use lowercase statefulset type for satisfactory

### DIFF
--- a/cluster/external/satisfactory/helmrelease.yaml
+++ b/cluster/external/satisfactory/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
   values:
     controllers:
       main:
-        type: StatefulSet
+        type: statefulset
         replicas: 0
         containers:
           app:


### PR DESCRIPTION
The app-template v5 schema requires lowercase `statefulset`, not `StatefulSet`. Fixes schema validation failure.