### PR TITLE
feat: add CNPG cluster for immich with import from existing postgres

### DIFF
--- a/cluster/media/immich/cnpg-cluster.yaml
+++ b/cluster/media/immich/cnpg-cluster.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: immich-cnpg
+  namespace: media
+spec:
+  instances: 1
+  imageName: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.3.0@sha256:87c050465fb969a68c7ac23e375e21f4c95cfacd0edce5fa1bc31e63b7891891
+
+  postgresql:
+    shared_preload_libraries:
+      - vectors.so
+      - vchord.so
+
+  storage:
+    size: 5Gi
+    storageClass: freenas-nfs-csi
+
+  enableSuperuserAccess: false
+  enablePDB: true
+
+  bootstrap:
+    initdb:
+      database: immich
+      owner: immich
+      import:
+        type: microservice
+        databases:
+          - immich
+        source:
+          externalCluster: existing-postgres
+
+  externalClusters:
+    - name: existing-postgres
+      connectionParameters:
+        host: immich-postgresql.media.svc.cluster.local
+        user: postgres
+        dbname: immich
+        sslmode: disable
+      password:
+        name: immich-postgresql
+        key: postgres-password


### PR DESCRIPTION
Creates a CNPG-managed PostgreSQL cluster for Immich using the official
`ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.3.0` image,
which bundles both VectorChord and pgvecto-rs for migration compatibility.

On first boot, CNPG will import the existing database from
`immich-postgresql.media.svc.cluster.local` via `pg_dump`. The existing
bitnami statefulset is protected with `helm.sh/resource-policy=keep` and
will be cleaned up manually after the chart 0.12.0 migration is verified.

Next PR will rewrite the HelmRelease to chart 0.12.0 pointing at this cluster.