### PR TITLE
fix: add namespace to immich-postgres HelmRelease

### DIFF
--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -2,6 +2,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: &app immich-postgres
+  namespace: media
 spec:
   chart:
     spec:


### PR DESCRIPTION
Unlike memos/mealie which use Kustomize namespace injection via kustomization.yaml files, the immich directory has no kustomization.yaml so namespaces must be explicit.