### PR TITLE
fix: use postgresql.parameters for shared_preload_libraries

### DIFF
--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -26,8 +26,8 @@ spec:
         size: 5Gi
         storageClass: freenas-nfs-csi
       postgresql:
-        shared_preload_libraries:
-          - vchord.so
+        parameters:
+          shared_preload_libraries: "vchord.so"
         extensions:
           - name: vchord
             image:


### PR DESCRIPTION
cluster chart 0.6.1 deprecated `cluster.postgresql.shared_preload_libraries` — must use `cluster.postgresql.parameters.shared_preload_libraries` (string) instead.