### PR TITLE
fix: remove shared_preload_libraries from immich-postgres CNPG cluster

### DIFF
--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -40,9 +40,6 @@ spec:
       storage:
         size: 5Gi
         storageClass: freenas-nfs-csi
-      postgresql:
-        parameters:
-          shared_preload_libraries: "vchord.so"
       enableSuperuserAccess: false
       enablePDB: true
 


### PR DESCRIPTION
## Summary

- CNPG 1.29.1 admission webhook rejects `shared_preload_libraries` set via `spec.postgresql.parameters` — it's a fixed parameter managed by the operator
- The VectorChord extension sidecar (added via `postRenderers`) handles library loading automatically
- Removes the now-invalid parameter so the Cluster object passes admission

## Test plan

- [ ] `immich-postgres` HelmRelease reconciles successfully
- [ ] CNPG Cluster reaches `Cluster in healthy state`
- [ ] `immich-postgres-1-0` pod starts with VectorChord sidecar