### PR TITLE
fix: correct postRenderer target name for VectorChord extension

### DIFF
--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
               group: postgresql.cnpg.io
               version: v1
               kind: Cluster
-              name: immich-postgres
+              name: immich-postgres-cluster
             patch: |
               - op: add
                 path: /spec/postgresql/extensions

--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -40,9 +40,6 @@ spec:
       storage:
         size: 5Gi
         storageClass: freenas-nfs-csi
-      postgresql:
-        parameters:
-          shared_preload_libraries: "vchord.so"
       enableSuperuserAccess: false
       enablePDB: true
 


### PR DESCRIPTION
## Summary

- The `cluster` chart names the rendered Cluster resource `immich-postgres-cluster` (appends `-cluster` suffix to the release name)
- The postRenderer kustomize patch was targeting `name: immich-postgres` which never matched, so `spec.postgresql.extensions` was never injected
- Fix: target `name: immich-postgres-cluster`

## Test plan

- [ ] `immich-postgres-cluster` has `spec.postgresql.extensions` with the vchord sidecar
- [ ] `vchord` shows up in `pg_available_extensions`