### PR TITLE
fix: switch immich-postgres CNPG cluster to PG17

### DIFF
--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
               group: postgresql.cnpg.io
               version: v1
               kind: Cluster
-              name: immich-postgres
+              name: immich-postgres-cluster
             patch: |
               - op: add
                 path: /spec/postgresql/extensions

--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -27,16 +27,16 @@ spec:
                 value:
                   - name: vchord
                     image:
-                      reference: ghcr.io/tensorchord/vchord-scratch:pg16-v1.1.1@sha256:b15cd02051cad0a8f4cb02dbd4cbdfee0acedbcd4c986337d0a1ddd1006a0feb
+                      reference: ghcr.io/tensorchord/vchord-scratch:pg17-v1.1.1@sha256:72b7cf886db4fafc3cfd831ff418b9effcee9f4a056d196bff219f914723ff23
   values:
     type: postgresql
     version:
-      postgresql: "16"
+      postgresql: "17"
       mode: standalone
 
     cluster:
       instances: 1
-      imageName: "ghcr.io/cloudnative-pg/postgresql:16@sha256:096c60451f809596865f37eb99ee99d23b20b0d54fb889bb35119fc2283f2f76"
+      imageName: "ghcr.io/cloudnative-pg/postgresql:17@sha256:d394417ac1209f7ad074eed7dc7f5078a8fe3de174032ad6c1488e2274df99be"
       storage:
         size: 5Gi
         storageClass: freenas-nfs-csi

--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -40,9 +40,6 @@ spec:
       storage:
         size: 5Gi
         storageClass: freenas-nfs-csi
-      postgresql:
-        parameters:
-          shared_preload_libraries: "vchord.so"
       enableSuperuserAccess: false
       enablePDB: true
 


### PR DESCRIPTION
## Summary

- CNPG's extension sidecar mechanism (`spec.postgresql.extensions`) uses the `extension_control_path` GUC, which was added in PostgreSQL 17
- PG16 cluster was failing with: `unrecognized configuration parameter "extension_control_path"` after the extension patch applied
- Fix: upgrade to PG17 (`ghcr.io/cloudnative-pg/postgresql:17`) and switch the vchord-scratch sidecar to the `pg17-v1.1.1` variant
- The broken PG16 cluster and its empty PVC were deleted manually; Flux will recreate fresh with PG17

## Test plan

- [ ] `immich-postgres-cluster` comes up healthy with PG17
- [ ] `vchord` appears in `pg_available_extensions`
- [ ] Ready to run dump/transform/restore from `immich-postgresql` statefulset