### PR TITLE
fix: use strategic merge patch for VectorChord extension injection

### DIFF
--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -22,12 +22,16 @@ spec:
               kind: Cluster
               name: immich-postgres-cluster
             patch: |
-              - op: add
-                path: /spec/postgresql/extensions
-                value:
-                  - name: vchord
-                    image:
-                      reference: ghcr.io/tensorchord/vchord-scratch:pg17-v1.1.1@sha256:72b7cf886db4fafc3cfd831ff418b9effcee9f4a056d196bff219f914723ff23
+              apiVersion: postgresql.cnpg.io/v1
+              kind: Cluster
+              metadata:
+                name: immich-postgres-cluster
+              spec:
+                postgresql:
+                  extensions:
+                    - name: vchord
+                      image:
+                        reference: ghcr.io/tensorchord/vchord-scratch:pg17-v1.1.1@sha256:72b7cf886db4fafc3cfd831ff418b9effcee9f4a056d196bff219f914723ff23
   values:
     type: postgresql
     version:


### PR DESCRIPTION
## Summary

- JSON Patch `add` on `/spec/postgresql/extensions` fails when `spec.postgresql` is absent from the Helm-rendered manifest: `doc is missing path: "/spec/postgresql/extensions"`
- The cluster chart only emits `spec.postgresql` when parameters are configured; since we removed `shared_preload_libraries`, the key is missing entirely
- Fix: switch from JSON Patch to strategic merge patch format, which handles missing parent paths correctly

## Test plan

- [ ] `immich-postgres` HelmRelease reconciles successfully
- [ ] `immich-postgres-cluster` reaches healthy state
- [ ] `vchord` appears in `pg_available_extensions`