### PR TITLE
fix: switch immich-postgres to PG18 for VectorChord extension sidecar

### DIFF
--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -31,16 +31,16 @@ spec:
                   extensions:
                     - name: vchord
                       image:
-                        reference: ghcr.io/tensorchord/vchord-scratch:pg17-v1.1.1@sha256:72b7cf886db4fafc3cfd831ff418b9effcee9f4a056d196bff219f914723ff23
+                        reference: ghcr.io/tensorchord/vchord-scratch:pg18-v1.1.1@sha256:0e1ac9e82d2ddeb1aa88e401e0e5cc305e39afa7556d10a7effb9f1fc4252bc5
   values:
     type: postgresql
     version:
-      postgresql: "17"
+      postgresql: "18"
       mode: standalone
 
     cluster:
       instances: 1
-      imageName: "ghcr.io/cloudnative-pg/postgresql:17@sha256:d394417ac1209f7ad074eed7dc7f5078a8fe3de174032ad6c1488e2274df99be"
+      imageName: "ghcr.io/cloudnative-pg/postgresql:18@sha256:34bd6045c06b85f8364f5dd447fa5d024adf725a9277c9ba58bd5fa01acae9ce"
       storage:
         size: 5Gi
         storageClass: freenas-nfs-csi


### PR DESCRIPTION
## Summary

- `extension_control_path` (the GUC that CNPG uses to configure the extension sidecar path) was introduced in **PostgreSQL 18**, not 17
- PG17 fails at boot with: `unrecognized configuration parameter "extension_control_path"`
- Fix: bump to PG18 (`ghcr.io/cloudnative-pg/postgresql:18`) and switch vchord-scratch to the `pg18-v1.1.1` variant
- Broken PG17 cluster and its empty PVC deleted manually

## Test plan

- [ ] `immich-postgres-cluster` starts healthy on PG18
- [ ] `vchord` present in `pg_available_extensions`
- [ ] Ready for dump/transform/restore from `immich-postgresql` bitnami statefulset