### PR TITLE
fix: use immich-app postgres PG16 image with VectorChord pre-installed

### DIFF
--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -13,34 +13,15 @@ spec:
         name: cloudnative-pg
         namespace: flux-system
   interval: 30m
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              group: postgresql.cnpg.io
-              version: v1
-              kind: Cluster
-              name: immich-postgres-cluster
-            patch: |
-              apiVersion: postgresql.cnpg.io/v1
-              kind: Cluster
-              metadata:
-                name: immich-postgres-cluster
-              spec:
-                postgresql:
-                  extensions:
-                    - name: vchord
-                      image:
-                        reference: ghcr.io/tensorchord/vchord-scratch:pg18-v1.1.1@sha256:0e1ac9e82d2ddeb1aa88e401e0e5cc305e39afa7556d10a7effb9f1fc4252bc5
   values:
     type: postgresql
     version:
-      postgresql: "18"
+      postgresql: "16"
       mode: standalone
 
     cluster:
       instances: 1
-      imageName: "ghcr.io/cloudnative-pg/postgresql:18@sha256:34bd6045c06b85f8364f5dd447fa5d024adf725a9277c9ba58bd5fa01acae9ce"
+      imageName: "ghcr.io/immich-app/postgres:16-vectorchord0.4.3-pgvector0.8.0-pgvectors0.3.0@sha256:e1466ace8276741f08eae74227e1dc7404fa4ecba0209792d9de8e81270e26ed"
       storage:
         size: 5Gi
         storageClass: freenas-nfs-csi

--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -31,16 +31,16 @@ spec:
                   extensions:
                     - name: vchord
                       image:
-                        reference: ghcr.io/tensorchord/vchord-scratch:pg17-v1.1.1@sha256:72b7cf886db4fafc3cfd831ff418b9effcee9f4a056d196bff219f914723ff23
+                        reference: ghcr.io/tensorchord/vchord-scratch:pg18-v1.1.1@sha256:0e1ac9e82d2ddeb1aa88e401e0e5cc305e39afa7556d10a7effb9f1fc4252bc5
   values:
     type: postgresql
     version:
-      postgresql: "17"
+      postgresql: "18"
       mode: standalone
 
     cluster:
       instances: 1
-      imageName: "ghcr.io/cloudnative-pg/postgresql:17@sha256:d394417ac1209f7ad074eed7dc7f5078a8fe3de174032ad6c1488e2274df99be"
+      imageName: "ghcr.io/cloudnative-pg/postgresql:18@sha256:34bd6045c06b85f8364f5dd447fa5d024adf725a9277c9ba58bd5fa01acae9ce"
       storage:
         size: 5Gi
         storageClass: freenas-nfs-csi


### PR DESCRIPTION
## Summary

- CNPG extension sidecars rely on Kubernetes image volumes (alpha in k8s 1.31, not available in our k3s 1.29.1 cluster)
- Removes all postRenderers/extension sidecar config that was causing repeated failures
- Switches `imageName` to `ghcr.io/immich-app/postgres:16-vectorchord0.4.3-pgvector0.8.0-pgvectors0.3.0` — Immich's own pre-built image with VectorChord, pgvector, and pgvecto.rs already compiled in for PG16
- Reverts to `version.postgresql: "16"` since we no longer need PG18 for the sidecar mechanism

## Test plan

- [ ] `immich-postgres-cluster` starts healthy
- [ ] `vchord` appears in `pg_available_extensions` 
- [ ] Ready for dump/transform/restore from `immich-postgresql` bitnami statefulset