### PR TITLE
fix: use cloudnative-vectorchord image for immich-postgres CNPG cluster

### DIFF
--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -13,25 +13,6 @@ spec:
         name: cloudnative-pg
         namespace: flux-system
   interval: 30m
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              group: postgresql.cnpg.io
-              version: v1
-              kind: Cluster
-              name: immich-postgres-cluster
-            patch: |
-              apiVersion: postgresql.cnpg.io/v1
-              kind: Cluster
-              metadata:
-                name: immich-postgres-cluster
-              spec:
-                postgresql:
-                  extensions:
-                    - name: vchord
-                      image:
-                        reference: ghcr.io/tensorchord/vchord-scratch:pg18-v1.1.1@sha256:0e1ac9e82d2ddeb1aa88e401e0e5cc305e39afa7556d10a7effb9f1fc4252bc5
   values:
     type: postgresql
     version:
@@ -40,7 +21,7 @@ spec:
 
     cluster:
       instances: 1
-      imageName: "ghcr.io/cloudnative-pg/postgresql:18@sha256:34bd6045c06b85f8364f5dd447fa5d024adf725a9277c9ba58bd5fa01acae9ce"
+      imageName: "ghcr.io/tensorchord/cloudnative-vectorchord:18-1.1.1@sha256:392b53675b403d6a2c72b673cc488a7c272514755dd818c622fb9ce4665193c4"
       storage:
         size: 5Gi
         storageClass: freenas-nfs-csi


### PR DESCRIPTION
## Summary

- Switches `imageName` from `ghcr.io/cloudnative-pg/postgresql:18` to `ghcr.io/tensorchord/cloudnative-vectorchord:18-1.1.1`, a CNPG-compatible PG18 image with vchord pre-installed
- Removes the `postRenderers` extension sidecar block (no longer needed)

## Why

Two blockers made the vchord-scratch sidecar approach unworkable:
1. **glibc mismatch** — `vchord.so` requires glibc 2.33+, the CNPG Bullseye image has 2.31
2. **Path layout mismatch** — CNPG expects extension files at `share/` and `lib/` at the image root; vchord-scratch uses the full PG filesystem tree (`usr/share/postgresql/18/extension/`)

The `cloudnative-vectorchord` image is built on Debian 12 (glibc 2.36), has UID 26, and ships both `vchord 1.1.1` and `vector 0.8.2` — verified working on the cluster.

## Test plan

- [ ] Cluster comes up healthy after merge
- [ ] `vchord` and `vector` visible in `pg_available_extensions`