### PR TITLE
feat: add vchord to shared_preload_libraries for immich-postgres

### DIFF
--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -28,6 +28,10 @@ spec:
       enableSuperuserAccess: false
       enablePDB: true
 
+      postgresql:
+        shared_preload_libraries:
+          - vchord
+
       initdb:
         database: immich
         owner: immich


### PR DESCRIPTION
## Summary

- Adds `vchord` to `cluster.postgresql.shared_preload_libraries` in the immich-postgres HelmRelease
- vchord requires this to be set before `CREATE EXTENSION vchord` will succeed (without it you get: `ERROR: vchord must be loaded via shared_preload_libraries`)
- The patch was already applied directly to the Cluster resource; this commit persists it via git so Flux doesn't revert it on next reconcile

## Test plan

- [ ] PR merges and Flux reconciles without errors
- [ ] `SHOW shared_preload_libraries;` in immich-postgres-cluster-1 returns `vchord`
- [ ] Re-run immich database restore — `CREATE EXTENSION vchord CASCADE` succeeds this time