### PR TITLE
feat: migrate immich database from bitnami postgresql to CNPG

### DIFF
--- a/cluster/media/immich/helmrelease.yaml
+++ b/cluster/media/immich/helmrelease.yaml
@@ -17,14 +17,13 @@ spec:
   values:
     env:
       REDIS_HOSTNAME: '{{ printf "%s-redis-master" .Release.Name }}'
-      DB_HOSTNAME: "{{ .Release.Name }}-postgresql"
-      DB_USERNAME: "{{ .Values.postgresql.global.postgresql.auth.username }}"
-      DB_DATABASE_NAME: "{{ .Values.postgresql.global.postgresql.auth.database }}"
-      # -- You should provide your own secret outside of this helm-chart and use `postgresql.global.postgresql.auth.existingSecret` to provide credentials to the postgresql instance
-      DB_PASSWORD: 
+      DB_HOSTNAME: "immich-postgres-cluster-rw"
+      DB_USERNAME: "immich"
+      DB_DATABASE_NAME: "immich"
+      DB_PASSWORD:
         valueFrom:
           secretKeyRef:
-            name: immich-postgresql
+            name: immich-postgres-cluster-app
             key: password
       IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
 
@@ -38,29 +37,7 @@ spec:
 
     # Dependencies
     postgresql:
-      enabled: true
-      image:
-        repository: tensorchord/pgvecto-rs
-        tag: pg14-v0.2.0@sha256:90724186f0a3517cf6914295b5ab410db9ce23190a2d9d0b9dd6463e3fa298f0
-      global:
-        postgresql:
-          auth:
-            existingSecret: immich-postgresql
-            database: immich
-            username: immich
-      primary:
-        resourcesPreset: "small"
-        initdb:
-          scripts:
-            create-extensions.sql: |
-              CREATE EXTENSION cube;
-              CREATE EXTENSION earthdistance;
-              CREATE EXTENSION vectors;
-        persistence:
-          enabled: true
-          existingClaim: immich-db
-        service:
-          type: LoadBalancer
+      enabled: false
 
     redis:
       enabled: true


### PR DESCRIPTION
## Summary

- Disables the bundled bitnami/pgvecto.rs PostgreSQL 14 statefulset
- Points immich at the `immich-postgres-cluster-rw` CNPG service (PG18 + vchord)
- Switches DB credentials to the CNPG-managed `immich-postgres-cluster-app` secret

## Data migration status

Database has been restored and verified:
- 7,000 assets
- 2 users
- 8,965 face embeddings
- 6,867 smart search embeddings
- Extensions: `vector 0.8.2`, `vchord 1.1.1`

## After merging

1. Flux reconciles — bitnami StatefulSet is removed, immich points at CNPG
2. Scale up immich: `kubectl scale deployment -n media immich-server immich-machine-learning --replicas=1`
3. Verify immich healthy at photos.wat.sn
4. Follow-up cleanup: delete `immich-db` PVC and `immich-postgresql` secret