### PR TITLE
feat: migrate planka to CNPG PG17 and upgrade to v2

### DIFF
--- a/cluster/home/planka/external-secret.yaml
+++ b/cluster/home/planka/external-secret.yaml
@@ -23,27 +23,3 @@ spec:
   dataFrom:
     - extract:
         key: *secretName
----
----
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: &secretName planka-db
-spec:
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: onepassword-connect
-  target:
-    name: *secretName
-    creationPolicy: Owner
-    deletionPolicy: "Delete"
-    template:
-      engineVersion: v2
-      data:
-        username: "{{ .dbUsername }}"
-        password: "{{ .dbPassword }}"
-        postgres-password: "{{ .postgresPassword }}"
-  dataFrom:
-    - extract:
-        key: planka

--- a/cluster/home/planka/helmrelease.yaml
+++ b/cluster/home/planka/helmrelease.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -6,7 +7,7 @@ spec:
   chart:
     spec:
       chart: *app
-      version:  0.2.26
+      version: 2.1.0
       sourceRef:
         kind: HelmRepository
         name: planka-charts
@@ -17,12 +18,16 @@ spec:
     image:
       repository: ghcr.io/plankanban/planka
       pullPolicy: IfNotPresent
-      tag: 1.26.3@sha256:e469d724985db3f560ef0aa2218d54536212459bf8ecbdbc9fd995fc3cbe29db
+      tag: 2.1.1@sha256:19b507ae3ab5cb1855c3f6984249e4a4881ed0b912febdfd492139c29bf10f39
 
     existingSecretkeySecret: planka
-
     existingAdminCredsSecret: planka
-    
+    existingDburlSecret: planka-postgres-cluster-app
+
+    persistence:
+      enabled: true
+      existingClaim: planka-data
+
     ingress:
       enabled: true
       className: "nginx"
@@ -44,16 +49,7 @@ spec:
         - *appHostInternal
 
     postgresql:
-      enabled: true
-      auth:
-        database: planka
-        existingSecret: planka-db
-      serviceBindings:
-        enabled: true
-      primary:
-        persistence:
-          enabled: true
-          existingClaim: planka-postgresql
+      enabled: false
 
     oidc:
       enabled: true

--- a/cluster/home/planka/kustomization.yaml
+++ b/cluster/home/planka/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - helmrelease.yaml
 - external-secret.yaml
 - pvc.yaml
+- postgres/helmrelease.yaml

--- a/cluster/home/planka/postgres/helmrelease.yaml
+++ b/cluster/home/planka/postgres/helmrelease.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: planka-postgres
+spec:
+  chart:
+    spec:
+      chart: cluster
+      version: 0.6.1
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+        namespace: flux-system
+  interval: 30m
+  values:
+    type: postgresql
+    version:
+      postgresql: "17"
+      mode: standalone
+
+    cluster:
+      instances: 1
+      storage:
+        size: 10Gi
+        storageClass: freenas-nfs-csi
+      enableSuperuserAccess: false
+      enablePDB: true
+
+      initdb:
+        database: planka
+        owner: planka

--- a/cluster/home/planka/pvc.yaml
+++ b/cluster/home/planka/pvc.yaml
@@ -1,7 +1,22 @@
+---
+# Remove after dump/restore migration to CNPG is complete
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: planka-postgresql
+spec:
+  resources:
+    requests:
+      storage: 10Gi
+  volumeMode: Filesystem
+  storageClassName: freenas-nfs-csi
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: planka-data
 spec:
   resources:
     requests:


### PR DESCRIPTION
## Summary

- Adds a CNPG PG17 cluster (`planka-postgres`) to replace the bitnami postgresql subchart
- Upgrades planka chart `0.2.26 → 2.1.0` and app image `1.26.3 → 2.1.1`
- Switches DB connection to `existingDburlSecret` pointing at the CNPG-generated app secret
- Enables `planka-data` PVC for planka v2's persistent data directory (`/app/data`)
- Removes `planka-db` ExternalSecret (credentials now managed by CNPG)

## Migration order

**Do not let Flux apply the planka HelmRelease update until the dump/restore is complete.** Recommended approach:

1. Merge this PR — Flux will create the CNPG cluster but planka HelmRelease will error (missing secret) until the restore is done
2. Suspend the planka HelmRelease: `flux suspend helmrelease -n planka planka`
3. Dump from existing bitnami pod:
   ```
   kubectl exec -n planka planka-postgresql-0 -- pg_dump -U planka planka > planka.sql
   ```
4. Wait for CNPG cluster pod `planka-postgres-cluster-1` to be Ready
5. Restore:
   ```
   kubectl exec -n planka -i planka-postgres-cluster-1 -- psql -U planka planka < planka.sql
   ```
6. Resume: `flux resume helmrelease -n planka planka`
7. Verify planka starts and data is intact
8. Follow-up PR: remove `planka-postgresql` PVC from `pvc.yaml`