### PR TITLE
chore: remove planka-postgresql PVC after CNPG migration

### DIFF
--- a/cluster/home/planka/pvc.yaml
+++ b/cluster/home/planka/pvc.yaml
@@ -1,18 +1,4 @@
 ---
-# Remove after dump/restore migration to CNPG is complete
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: planka-postgresql
-spec:
-  resources:
-    requests:
-      storage: 10Gi
-  volumeMode: Filesystem
-  storageClassName: freenas-nfs-csi
-  accessModes:
-    - ReadWriteOnce
----
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
Removes the legacy bitnami postgresql PVC now that the migration to CNPG is complete and planka v2 is running healthy.