### PR TITLE
feat: migrate authentik to CNPG PG17 and upgrade to v2026.5.3

### DIFF
--- a/cluster/identity/authentik/external-secret.yaml
+++ b/cluster/identity/authentik/external-secret.yaml
@@ -16,10 +16,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        username: "{{ .username }}"
-        password: "{{ .password }}"
-        postgres-password: "{{ .postgresPassword }}"
-        secretKey : "{{ .secretKey }}"
+        secretKey: "{{ .secretKey }}"
         geoipId: "{{ .geoipId }}"
         geoipKey: "{{ .geoipKey }}"
   dataFrom:

--- a/cluster/identity/authentik/helmrelease.yaml
+++ b/cluster/identity/authentik/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: authentik
-      version: 2024.12.3
+      version: 2026.5.3
       sourceRef:
         kind: HelmRepository
         name: authentik-charts
@@ -16,11 +16,11 @@ spec:
       interval: 5m
   valuesFrom:
     - kind: Secret
-      name: authentik-secrets
+      name: authentik-postgres-cluster-app
       valuesKey: username
       targetPath: authentik.postgresql.user
     - kind: Secret
-      name: authentik-secrets
+      name: authentik-postgres-cluster-app
       valuesKey: password
       targetPath: authentik.postgresql.password
     - kind: Secret
@@ -31,25 +31,11 @@ spec:
     global:
       image:
         repository: ghcr.io/goauthentik/server
-        tag: 2024.12.5@sha256:717323d68507fb76dd79f8958f42ce57f8ae0c10a55a7807efa1cfec5752b77c
-    redis:
-      enabled: true
-    postgresql:
-      enabled: true
-      global:
-        postgresql:
-          auth:
-            existingSecret: authentik-secrets
-            database: authentik
-            username: authentik-user
-      image:
-        registry: docker.io
-        repository: bitnami/postgresql
-        tag: 16.4.0@sha256:75c5d322fd11bb10a0e4ddebf4ab312aa9ec2bbcf2b64986f7d87127483e2b14
-      primary:
-        persistence:
-          enabled: true
-          existingClaim: authentik-postgres
+        tag: 2026.5.3
+    authentik:
+      postgresql:
+        host: authentik-postgres-cluster-rw
+        name: authentik
     geoip:
       enabled: false
       existingSecret:
@@ -57,7 +43,7 @@ spec:
         accountId: geoipId
         licenseKey: geoipKey
     server:
-      ingress: 
+      ingress:
         enabled: true
         ingressClassName: "nginx"
         tls:
@@ -67,6 +53,6 @@ spec:
             secretName: auth-cert
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-prod
-        hosts: 
-        - auth.internal.wat.sn   
+        hosts:
+        - auth.internal.wat.sn
         - auth.wat.sn

--- a/cluster/identity/authentik/postgres/helmrelease.yaml
+++ b/cluster/identity/authentik/postgres/helmrelease.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: authentik-postgres
+  namespace: identity
+spec:
+  chart:
+    spec:
+      chart: cluster
+      version: 0.6.1
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg
+        namespace: flux-system
+  interval: 30m
+  values:
+    type: postgresql
+    version:
+      postgresql: "17"
+      mode: standalone
+
+    cluster:
+      instances: 1
+      storage:
+        size: 8Gi
+        storageClass: freenas-nfs-csi
+      enableSuperuserAccess: false
+      enablePDB: true
+
+      initdb:
+        database: authentik
+        owner: authentik-user

--- a/cluster/identity/authentik/pvc.yaml
+++ b/cluster/identity/authentik/pvc.yaml
@@ -1,3 +1,4 @@
+# Remove after dump/restore migration to CNPG is complete
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:


### PR DESCRIPTION
## Summary

- Adds CNPG PG17 cluster (`authentik-postgres`) with `initdb.owner: authentik-user` to match existing DB user
- Upgrades authentik chart `2024.12.3 → 2026.5.3` and image `2024.12.5 → 2026.5.3`
- **Drops redis subchart** — removed upstream in chart 2025.10.3; authentik 2025+ uses DB-backed queuing instead
- Switches DB connection from bitnami subchart to CNPG; `valuesFrom` now pulls credentials from `authentik-postgres-cluster-app`
- Removes username/password/postgres-password fields from `authentik-secrets` ExternalSecret (no longer needed)
- Authentik DB migrations (2025.x → 2026.x) run automatically on first startup

## Migration order

**Do not let Flux apply the authentik HelmRelease update until the dump/restore is complete.** Authentik is an IdP — downtime affects all SSO.

1. Merge this PR — Flux creates the CNPG cluster; authentik HelmRelease will fail until credentials are ready
2. Suspend: `flux suspend helmrelease -n identity authentik`
3. Dump from bitnami pod:
   ```
   kubectl exec -n identity authentik-postgresql-0 -- bash -c \
     'PGPASSWORD=$POSTGRES_POSTGRES_PASSWORD pg_dump -U postgres authentik' > authentik.sql
   ```
4. Wait for `authentik-postgres-cluster-1` to be Ready
5. Restore:
   ```
   kubectl exec -n identity -i authentik-postgres-cluster-1 -- psql -U postgres authentik < authentik.sql
   ```
6. Resume: `flux resume helmrelease -n identity authentik`
7. Monitor startup — authentik will run pending DB migrations (2025.x/2026.x) automatically
8. Follow-up PR: remove `authentik-postgres` PVC from `pvc.yaml`