### PR TITLE
feat: migrate external-dns from bitnami to kubernetes-sigs chart

### DIFF
--- a/cluster/flux-system/helm-chart-repos/external-dns.yaml
+++ b/cluster/flux-system/helm-chart-repos/external-dns.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-dns-charts
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://kubernetes-sigs.github.io/external-dns/
+  timeout: 3m

--- a/cluster/network/external-dns/helmrelease.yaml
+++ b/cluster/network/external-dns/helmrelease.yaml
@@ -8,31 +8,42 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 9.0.3
+      version: 1.21.1
       sourceRef:
         kind: HelmRepository
-        name: bitnami-charts
+        name: external-dns-charts
         namespace: flux-system
       interval: 5m
   values:
+    provider:
+      name: coredns
     domainFilters:
-     - internal.corywatson.net
-     - external.corywatson.net
-     - internal.wat.sn
-    provider: coredns
-    coredns:
-      etcdEndpoints: "https://10.0.99.50:2379,https://10.0.99.51:2379,https://10.0.99.52:2379"
-      etcdTLS:
-        enabled: true
-        secretName: etcd-certs
-        caFilename: server-ca.crt
-        certFilename: server-client.crt
-        keyFilename: server-client.key
-    crd: 
-      create: true
-      apiVersion: externaldns.k8s.io/v1alpha1
-      kind: DNSEndpoint
-    sources: 
+      - internal.corywatson.net
+      - external.corywatson.net
+      - internal.wat.sn
+    sources:
       - service
       - ingress
       - crd
+    policy: upsert-only
+    interval: 1m
+    extraArgs:
+      - --crd-source-kind=DNSEndpoint
+    env:
+      - name: ETCD_URLS
+        value: "https://10.0.99.50:2379,https://10.0.99.51:2379,https://10.0.99.52:2379"
+      - name: ETCD_CERT_FILE
+        value: /etc/coredns/tls/etcd/server-client.crt
+      - name: ETCD_KEY_FILE
+        value: /etc/coredns/tls/etcd/server-client.key
+      - name: ETCD_CA_FILE
+        value: /etc/coredns/tls/etcd/server-ca.crt
+    extraVolumes:
+      - name: etcd-certs
+        secret:
+          secretName: etcd-certs
+          defaultMode: 0400
+    extraVolumeMounts:
+      - name: etcd-certs
+        mountPath: /etc/coredns/tls/etcd
+        readOnly: true


### PR DESCRIPTION
## Summary
- Bitnami chart 9.0.3 uses an OCI registry URL (`oci://registry-1.docker.io`) which Flux's legacy `HelmRepository` type cannot pull — release has been stuck trying to upgrade since December 2025
- Adds new `HelmRepository` pointing to `https://kubernetes-sigs.github.io/external-dns/`
- Migrates `HelmRelease` to `external-dns-charts/external-dns@1.21.1`
- All config is a direct translation from the running bitnami pod:
  - `provider: coredns` → `provider.name: coredns`
  - etcd TLS via `extraVolumes` + `extraVolumeMounts` + `env` (same mount path as current pod)
  - `--crd-source-kind=DNSEndpoint` via `extraArgs`
  - `sources`, `domainFilters`, `policy`, `interval` unchanged

## Test plan
- [ ] Flux reconciles `external-dns-charts` HelmRepository successfully
- [ ] HelmRelease upgrades to `1.21.1` without errors
- [ ] Pod logs show `All records are already up to date` (or DNS sync activity)
- [ ] Existing DNS records in etcd are unchanged