### PR TITLE
fix: add external-dns HelmRepository to helm-chart-repos kustomization

### DIFF
--- a/cluster/flux-system/helm-chart-repos/kustomization.yaml
+++ b/cluster/flux-system/helm-chart-repos/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - code-server.yaml
   - coredns.yaml
   - democratic-csi.yaml
+  - external-dns.yaml
   - external-secrets.yaml
   - immich.yaml
   - ingress-nginx.yaml


### PR DESCRIPTION
Missed adding external-dns.yaml to the explicit resource list in helm-chart-repos/kustomization.yaml — Flux couldn't create the HelmRepository without it.