### PR TITLE
fix: add DNSEndpoint CRD for external-dns crd source

### DIFF
--- a/cluster/network/external-dns/crd.yaml
+++ b/cluster/network/external-dns/crd.yaml
@@ -1,0 +1,76 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/external-dns/pull/2007
+  name: dnsendpoints.externaldns.k8s.io
+spec:
+  group: externaldns.k8s.io
+  names:
+    kind: DNSEndpoint
+    listKind: DNSEndpointList
+    plural: dnsendpoints
+    singular: dnsendpoint
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            DNSEndpoint is a contract that a user-specified CRD must implement to be used as a source for external-dns.
+            The user-specified CRD should also have the status sub-resource.
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DNSEndpointSpec defines the desired state of DNSEndpoint
+              properties:
+                endpoints:
+                  items:
+                    description: Endpoint is a high-level way of a connection between a service and an IP
+                    properties:
+                      dnsName:
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      providerSpecific:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      recordTTL:
+                        format: int64
+                        type: integer
+                      recordType:
+                        type: string
+                      setIdentifier:
+                        type: string
+                      targets:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: DNSEndpointStatus defines the observed state of DNSEndpoint
+              properties:
+                observedGeneration:
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
The bitnami chart managed this CRD in its templates directory (not crds/), so Helm removed it when upgrading to the kubernetes-sigs chart. Adds the CRD as a standalone manifest so Flux manages it going forward.