### PR TITLE
feat: add system-upgrade-controller to GitOps management

### DIFF
--- a/cluster/cert-manager/cert-manager/kustomization.yaml
+++ b/cluster/cert-manager/cert-manager/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - certmanager-sealed-secrets.yaml
+  - helmrelease.yaml
+  - production-issuer.yaml
+  - self-signed.yaml
+  - staging-issuer.yaml

--- a/cluster/cert-manager/kustomization.yaml
+++ b/cluster/cert-manager/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - cert-manager

--- a/cluster/default/kustomization.yaml
+++ b/cluster/default/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster/external/kustomization.yaml
+++ b/cluster/external/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - minecraft
+  - satisfactory
+  - vrising

--- a/cluster/external/minecraft/kustomization.yaml
+++ b/cluster/external/minecraft/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/cluster/external/satisfactory/kustomization.yaml
+++ b/cluster/external/satisfactory/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - pvc.yaml

--- a/cluster/external/vrising/kustomization.yaml
+++ b/cluster/external/vrising/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - pvc.yaml
+  - sealed-secret.yaml
+  - service.yaml

--- a/cluster/home/planka/postgres/kustomization.yaml
+++ b/cluster/home/planka/postgres/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/cluster/identity/authentik/kustomization.yaml
+++ b/cluster/identity/authentik/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml
+  - helmrelease.yaml
+  - postgres

--- a/cluster/identity/authentik/postgres/kustomization.yaml
+++ b/cluster/identity/authentik/postgres/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/cluster/identity/kustomization.yaml
+++ b/cluster/identity/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - authentik

--- a/cluster/internal/kustomization.yaml
+++ b/cluster/internal/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - node-feature-discovery
+  - renovate

--- a/cluster/internal/node-feature-discovery/kustomization.yaml
+++ b/cluster/internal/node-feature-discovery/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/cluster/internal/renovate/kustomization.yaml
+++ b/cluster/internal/renovate/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - github-token-sealed-secret.yaml
+  - helmrelease.yaml

--- a/cluster/kube-system/container-registry/gcp-artifact-registry/kustomization.yaml
+++ b/cluster/kube-system/container-registry/gcp-artifact-registry/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml

--- a/cluster/kube-system/container-registry/kustomization.yaml
+++ b/cluster/kube-system/container-registry/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gcp-artifact-registry

--- a/cluster/kube-system/democratic-csi/kustomization.yaml
+++ b/cluster/kube-system/democratic-csi/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - freenas-iscsi.yaml
+  - freenas-nfs.yaml
+  - freenas-sealed-secrets.yaml

--- a/cluster/kube-system/intel-device-plugin-operator/app/kustomization.yaml
+++ b/cluster/kube-system/intel-device-plugin-operator/app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/cluster/kube-system/intel-device-plugin-operator/gpu/kustomization.yaml
+++ b/cluster/kube-system/intel-device-plugin-operator/gpu/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/cluster/kube-system/intel-device-plugin-operator/kustomization.yaml
+++ b/cluster/kube-system/intel-device-plugin-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - app
+  - gpu

--- a/cluster/kube-system/kustomization.yaml
+++ b/cluster/kube-system/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - container-registry
+  - democratic-csi
+  - intel-device-plugin-operator
+  - sealed-secrets

--- a/cluster/kube-system/sealed-secrets/kustomization.yaml
+++ b/cluster/kube-system/sealed-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/cluster/kustomization.yaml
+++ b/cluster/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cert-manager
+  - cnpg
+  - default
+  - external
+  - external-secrets
+  - flux-system
+  - home
+  - identity
+  - internal
+  - kube-system
+  - media
+  - network
+  - observability
+  - system-upgrade

--- a/cluster/media/immich/kustomization.yaml
+++ b/cluster/media/immich/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - db-credentials-sealed-secrets.yaml
+  - helmrelease.yaml
+  - pvc.yaml
+  - postgres

--- a/cluster/media/immich/postgres/kustomization.yaml
+++ b/cluster/media/immich/postgres/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/cluster/media/jellyfin/kustomization.yaml
+++ b/cluster/media/jellyfin/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - pvc.yaml

--- a/cluster/media/kustomization.yaml
+++ b/cluster/media/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - immich
+  - jellyfin

--- a/cluster/network/cloudflared/kustomization.yaml
+++ b/cluster/network/cloudflared/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cloudflared-deployment-tunnel.yaml
+  - cloudflared-tunnel-sealed-secrets.yaml

--- a/cluster/network/coredns/kustomization.yaml
+++ b/cluster/network/coredns/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/cluster/network/dns-records/kustomization.yaml
+++ b/cluster/network/dns-records/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nas-a

--- a/cluster/network/dns-records/nas-a/kustomization.yaml
+++ b/cluster/network/dns-records/nas-a/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - record.yaml

--- a/cluster/network/etcd/kustomization.yaml
+++ b/cluster/network/etcd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret.yaml

--- a/cluster/network/external-dns/kustomization.yaml
+++ b/cluster/network/external-dns/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - crd.yaml
+  - helmrelease.yaml

--- a/cluster/network/ingress-nginx/kustomization.yaml
+++ b/cluster/network/ingress-nginx/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml

--- a/cluster/network/kustomization.yaml
+++ b/cluster/network/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - cloudflared
+  - coredns
+  - dns-records
+  - etcd
+  - external-dns
+  - ingress-nginx
+  - metallb

--- a/cluster/network/metallb/kustomization.yaml
+++ b/cluster/network/metallb/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - config.yaml
+  - helmrelease.yaml

--- a/cluster/observability/kustomization.yaml
+++ b/cluster/observability/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/cluster/system-upgrade/helmrelease.yaml
+++ b/cluster/system-upgrade/helmrelease.yaml
@@ -1,0 +1,65 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: system-upgrade-controller
+  namespace: system-upgrade
+spec:
+  chart:
+    spec:
+      chart: app-template
+      version: 3.7.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+      interval: 30m
+  interval: 30m
+  values:
+    controllers:
+      system-upgrade-controller:
+        replicas: 2
+        strategy: RollingUpdate
+        pod:
+          securityContext:
+            runAsUser: 65534
+            runAsGroup: 65534
+            runAsNonRoot: true
+          tolerations:
+            - key: CriticalAddonsOnly
+              operator: Exists
+            - key: node-role.kubernetes.io/master
+              operator: Exists
+              effect: NoSchedule
+            - key: node-role.kubernetes.io/controlplane
+              operator: Exists
+              effect: NoSchedule
+            - key: node-role.kubernetes.io/control-plane
+              operator: Exists
+              effect: NoSchedule
+        containers:
+          app:
+            image:
+              repository: docker.io/rancher/system-upgrade-controller
+              tag: v0.19.2
+            env:
+              SYSTEM_UPGRADE_CONTROLLER_NAME: system-upgrade-controller
+              SYSTEM_UPGRADE_CONTROLLER_LEADER_ELECT: true
+              SYSTEM_UPGRADE_JOB_PRIVILEGED: true
+              SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: "99"
+              SYSTEM_UPGRADE_CONTROLLER_NAMESPACE:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              SYSTEM_UPGRADE_CONTROLLER_NODE_NAME:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    serviceAccount:
+      create: true
+      name: system-upgrade-controller

--- a/cluster/system-upgrade/kustomization.yaml
+++ b/cluster/system-upgrade/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrelease.yaml

--- a/cluster/system-upgrade/namespace.yaml
+++ b/cluster/system-upgrade/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system-upgrade


### PR DESCRIPTION
## Summary
- Adds `cluster/system-upgrade/` with namespace and HelmRelease manifests
- SUC was previously applied directly via `kubectl apply` and not tracked in git
- Updates image from `v0.15.0` → `v0.19.2` (the old version timed out on k3s 1.35 upgrades)

## Note
The live HelmRelease has already been patched to v0.19.2 to unblock the in-progress k3s 1.32→1.36 upgrade chain. This PR brings the repo in sync with that state.