### PR TITLE
fix: use all 3 etcd endpoints in coredns-primary

### DIFF
--- a/cluster/network/coredns/helmrelease.yaml
+++ b/cluster/network/coredns/helmrelease.yaml
@@ -60,9 +60,9 @@ spec:
           configBlock: |-
             stubzones
             path /skydns
-            endpoint https://10.0.99.50:2379
+            endpoint https://10.0.99.50:2379 https://10.0.99.51:2379 https://10.0.99.52:2379
             tls /etc/coredns/tls/etcd/server-client.crt /etc/coredns/tls/etcd/server-client.key /etc/coredns/tls/etcd/server-ca.crt
-    extraSecrets: 
+    extraSecrets:
       - name: etcd-certs
         mountPath: /etc/coredns/tls/etcd
         defaultMode: 420


### PR DESCRIPTION
## Summary

- `coredns-secondary` already had all 3 etcd endpoints; `coredns-primary` was only pointing at `rpi-master` (10.0.99.50:2379)
- If rpi-master goes down (as happened during the Jun 15 power outage), primary DNS loses etcd-backed internal records while secondary continues serving correctly — asymmetric behavior that's hard to debug

## Change

```
- endpoint https://10.0.99.50:2379
+ endpoint https://10.0.99.50:2379 https://10.0.99.51:2379 https://10.0.99.52:2379
```

Both instances now use identical etcd configuration.