### PR TITLE
fix: add dependsOn for app -> postgres HelmReleases

### DIFF
--- a/cluster/home/mealie/app/helmrelease.yaml
+++ b/cluster/home/mealie/app/helmrelease.yaml
@@ -4,6 +4,8 @@ metadata:
   name: &app mealie
 spec:
   interval: 30m
+  dependsOn:
+    - name: mealie-postgresql
   chart:
     spec:
       chart: app-template

--- a/cluster/home/memos/app/helmrelease.yaml
+++ b/cluster/home/memos/app/helmrelease.yaml
@@ -5,6 +5,8 @@ metadata:
   name: &app memos
 spec:
   interval: 30m
+  dependsOn:
+    - name: memos-postgresql
   upgrade:
     force: true
   chart:

--- a/cluster/home/planka/helmrelease.yaml
+++ b/cluster/home/planka/helmrelease.yaml
@@ -4,6 +4,8 @@ kind: HelmRelease
 metadata:
   name: &app planka
 spec:
+  dependsOn:
+    - name: planka-postgres
   chart:
     spec:
       chart: *app

--- a/cluster/identity/authentik/helmrelease.yaml
+++ b/cluster/identity/authentik/helmrelease.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: identity
 spec:
   interval: 5m
+  dependsOn:
+    - name: authentik-postgres
   chart:
     spec:
       chart: authentik

--- a/cluster/media/immich/helmrelease.yaml
+++ b/cluster/media/immich/helmrelease.yaml
@@ -5,6 +5,8 @@ metadata:
   name: immich
   namespace: media
 spec:
+  dependsOn:
+    - name: immich-postgres
   chart:
     spec:
       chart: immich


### PR DESCRIPTION
## Summary

- No HelmReleases had `dependsOn` configured
- On fresh bootstrap or post-recovery, Flux deploys apps and their databases simultaneously — apps crash because the CNPG cluster isn't ready, requiring manual `flux reconcile` intervention
- Adds explicit ordering so apps wait for their database HelmRelease to be healthy before deploying

## Changes

| App | Depends On |
|---|---|
| memos | memos-postgresql |
| planka | planka-postgres |
| mealie | mealie-postgresql |
| authentik | authentik-postgres |
| immich | immich-postgres |

## Test plan

- [ ] Verify Flux reconciles all 5 apps successfully after merge
- [ ] On next bootstrap/recovery, confirm apps come up cleanly without manual intervention