### PR TITLE
fix: add install/upgrade remediation to all HelmReleases

### DIFF
--- a/cluster/cert-manager/cert-manager/helmrelease.yaml
+++ b/cluster/cert-manager/cert-manager/helmrelease.yaml
@@ -17,8 +17,13 @@ spec:
   
   install:
     crds: CreateReplace
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
 
   values:
     installCRDs: true

--- a/cluster/cnpg/helmrelease.yaml
+++ b/cluster/cnpg/helmrelease.yaml
@@ -12,6 +12,13 @@ spec:
         name: cloudnative-pg
         namespace: flux-system
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     crds:
       create: true

--- a/cluster/external-secrets/app/helmrelease.yaml
+++ b/cluster/external-secrets/app/helmrelease.yaml
@@ -14,8 +14,14 @@ spec:
         kind: HelmRepository
         name: external-secrets-charts
         namespace: flux-system
+  install:
+    remediation:
+      retries: 3
   upgrade:
     crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     installCRDs: true
     crds:

--- a/cluster/external-secrets/stores/1password/helmrelease.yaml
+++ b/cluster/external-secrets/stores/1password/helmrelease.yaml
@@ -5,8 +5,14 @@ metadata:
   name: &app onepassword-connect
 spec:
   interval: 30m
+  install:
+    remediation:
+      retries: 3
   upgrade:
     force: true
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   chart:
     spec:
       chart: app-template

--- a/cluster/external/satisfactory/helmrelease.yaml
+++ b/cluster/external/satisfactory/helmrelease.yaml
@@ -14,8 +14,14 @@ spec:
         name: bjw-s-charts
         namespace: flux-system
   maxHistory: 3
+  install:
+    remediation:
+      retries: 3
   upgrade:
     force: true
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/values.schema.json
   values:
     controllers:

--- a/cluster/home/homeassistant/helmrelease.yaml
+++ b/cluster/home/homeassistant/helmrelease.yaml
@@ -14,6 +14,13 @@ spec:
         namespace: flux-system
   interval: 30m
   maxHistory: 3
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/values.schema.json
   values:
     controllers:

--- a/cluster/home/mealie/app/helmrelease.yaml
+++ b/cluster/home/mealie/app/helmrelease.yaml
@@ -15,6 +15,13 @@ spec:
         name: bjw-s-charts
         namespace: flux-system
   maxHistory: 3
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/app-template-5.0.1/charts/other/app-template/values.schema.json
   values:
     controllers:

--- a/cluster/home/mealie/database/helmrelease.yaml
+++ b/cluster/home/mealie/database/helmrelease.yaml
@@ -12,6 +12,13 @@ spec:
         name: cloudnative-pg
         namespace: flux-system
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     type: postgresql
     version:

--- a/cluster/home/memos/app/helmrelease.yaml
+++ b/cluster/home/memos/app/helmrelease.yaml
@@ -7,8 +7,14 @@ spec:
   interval: 30m
   dependsOn:
     - name: memos-postgresql
+  install:
+    remediation:
+      retries: 3
   upgrade:
     force: true
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   chart:
     spec:
       chart: app-template

--- a/cluster/home/memos/postgres/helmrelease.yaml
+++ b/cluster/home/memos/postgres/helmrelease.yaml
@@ -12,6 +12,13 @@ spec:
         name: cloudnative-pg
         namespace: flux-system
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     type: postgresql
     version:

--- a/cluster/home/planka/helmrelease.yaml
+++ b/cluster/home/planka/helmrelease.yaml
@@ -15,6 +15,13 @@ spec:
         name: planka-charts
         namespace: flux-system
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     replicaCount: 1
     image:

--- a/cluster/home/planka/postgres/helmrelease.yaml
+++ b/cluster/home/planka/postgres/helmrelease.yaml
@@ -13,6 +13,13 @@ spec:
         name: cloudnative-pg
         namespace: flux-system
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     type: postgresql
     version:

--- a/cluster/identity/authentik/helmrelease.yaml
+++ b/cluster/identity/authentik/helmrelease.yaml
@@ -7,6 +7,13 @@ spec:
   interval: 5m
   dependsOn:
     - name: authentik-postgres
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   chart:
     spec:
       chart: authentik

--- a/cluster/identity/authentik/postgres/helmrelease.yaml
+++ b/cluster/identity/authentik/postgres/helmrelease.yaml
@@ -14,6 +14,13 @@ spec:
         name: cloudnative-pg
         namespace: flux-system
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     type: postgresql
     version:

--- a/cluster/internal/node-feature-discovery/helmrelease.yaml
+++ b/cluster/internal/node-feature-discovery/helmrelease.yaml
@@ -14,6 +14,13 @@ spec:
         name: nfd-charts
         namespace: flux-system
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     image:
       repository: gcr.io/k8s-staging-nfd/node-feature-discovery

--- a/cluster/internal/renovate/helmrelease.yaml
+++ b/cluster/internal/renovate/helmrelease.yaml
@@ -14,6 +14,13 @@ spec:
         name: renovate-charts
         namespace: flux-system
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     cronjob:
       # -- Schedules the job to run using cron notation

--- a/cluster/kube-system/intel-device-plugin-operator/app/helmrelease.yaml
+++ b/cluster/kube-system/intel-device-plugin-operator/app/helmrelease.yaml
@@ -17,6 +17,12 @@ spec:
         namespace: flux-system
   install:
     crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     manager:
       devices:

--- a/cluster/kube-system/intel-device-plugin-operator/gpu/helmrelease.yaml
+++ b/cluster/kube-system/intel-device-plugin-operator/gpu/helmrelease.yaml
@@ -7,6 +7,13 @@ metadata:
   namespace: kube-system
 spec:
   interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   chart:
     spec:
       chart: intel-device-plugins-gpu

--- a/cluster/kube-system/sealed-secrets/helmrelease.yaml
+++ b/cluster/kube-system/sealed-secrets/helmrelease.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: kube-system
 spec:
   interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   chart:
     spec:
       chart: sealed-secrets

--- a/cluster/media/immich/helmrelease.yaml
+++ b/cluster/media/immich/helmrelease.yaml
@@ -16,6 +16,13 @@ spec:
         name: immich-charts
         namespace: flux-system
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     controllers:
       main:

--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -13,6 +13,13 @@ spec:
         name: cloudnative-pg
         namespace: flux-system
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     type: postgresql
     version:

--- a/cluster/media/jellyfin/helmrelease.yaml
+++ b/cluster/media/jellyfin/helmrelease.yaml
@@ -15,8 +15,14 @@ spec:
         name: bjw-s-charts
         namespace: flux-system
   interval: 30m
+  install:
+    remediation:
+      retries: 3
   upgrade:
     force: true
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     defaultPodOptions:
       securityContext:

--- a/cluster/network/coredns/helmrelease.yaml
+++ b/cluster/network/coredns/helmrelease.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: network
 spec:
   interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   chart:
     spec:
       chart: coredns
@@ -74,6 +81,13 @@ metadata:
   namespace: network
 spec:
   interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   chart:
     spec:
       chart: coredns

--- a/cluster/network/external-dns/helmrelease.yaml
+++ b/cluster/network/external-dns/helmrelease.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: network
 spec:
   interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   chart:
     spec:
       chart: external-dns

--- a/cluster/network/ingress-nginx/helmrelease.yaml
+++ b/cluster/network/ingress-nginx/helmrelease.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: network
 spec:
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   chart:
     spec:
       chart: ingress-nginx

--- a/cluster/network/metallb/helmrelease.yaml
+++ b/cluster/network/metallb/helmrelease.yaml
@@ -5,6 +5,13 @@ metadata:
   namespace: network
 spec:
   interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   chart:
     spec:
       chart: metallb

--- a/cluster/system-upgrade/helmrelease.yaml
+++ b/cluster/system-upgrade/helmrelease.yaml
@@ -14,6 +14,13 @@ spec:
         namespace: flux-system
       interval: 30m
   interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
   values:
     controllers:
       system-upgrade-controller:


### PR DESCRIPTION
## Summary

- No HelmReleases had remediation configured — a failed install or upgrade would sit in `Failed` state permanently with no automatic retry or rollback
- Adds `install.remediation.retries: 3` and `upgrade.remediation.retries: 3 / remediateLastFailure: true` to all 27 active HelmReleases
- Files that already had `install`/`upgrade` blocks (cert-manager CRDs, external-secrets CRDs, force upgrades) have remediation merged into the existing block rather than duplicated
- Skipped `cluster/external/minecraft/helmrelease.yaml` — entirely commented out

## Test plan

- [ ] Flux reconciles all HelmReleases successfully after merge
- [ ] Verify no HelmRelease is stuck in Failed state