### PR TITLE
fix: enable drift detection on all HelmReleases

### DIFF
--- a/cluster/cert-manager/cert-manager/helmrelease.yaml
+++ b/cluster/cert-manager/cert-manager/helmrelease.yaml
@@ -4,6 +4,8 @@ metadata:
   name: cert-manager
   namespace: cert-manager
 spec:
+  driftDetection:
+    mode: enabled
   interval: 30m
   chart:
     spec:

--- a/cluster/cnpg/helmrelease.yaml
+++ b/cluster/cnpg/helmrelease.yaml
@@ -3,6 +3,8 @@ kind: HelmRelease
 metadata:
   name: &app cnpg
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: cloudnative-pg

--- a/cluster/external-secrets/app/helmrelease.yaml
+++ b/cluster/external-secrets/app/helmrelease.yaml
@@ -5,6 +5,8 @@ kind: HelmRelease
 metadata:
   name: external-secrets
 spec:
+  driftDetection:
+    mode: enabled
   interval: 30m
   chart:
     spec:

--- a/cluster/external-secrets/stores/1password/helmrelease.yaml
+++ b/cluster/external-secrets/stores/1password/helmrelease.yaml
@@ -4,6 +4,8 @@ kind: HelmRelease
 metadata:
   name: &app onepassword-connect
 spec:
+  driftDetection:
+    mode: enabled
   interval: 30m
   install:
     remediation:

--- a/cluster/external/satisfactory/helmrelease.yaml
+++ b/cluster/external/satisfactory/helmrelease.yaml
@@ -4,6 +4,8 @@ metadata:
   name: satisfactory
   namespace: external
 spec:
+  driftDetection:
+    mode: enabled
   interval: 5m
   chart:
     spec:

--- a/cluster/home/homeassistant/helmrelease.yaml
+++ b/cluster/home/homeassistant/helmrelease.yaml
@@ -4,6 +4,8 @@ kind: HelmRelease
 metadata:
   name: home-assistant
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: app-template

--- a/cluster/home/mealie/app/helmrelease.yaml
+++ b/cluster/home/mealie/app/helmrelease.yaml
@@ -3,6 +3,8 @@ kind: HelmRelease
 metadata:
   name: &app mealie
 spec:
+  driftDetection:
+    mode: enabled
   interval: 30m
   dependsOn:
     - name: mealie-postgresql

--- a/cluster/home/mealie/database/helmrelease.yaml
+++ b/cluster/home/mealie/database/helmrelease.yaml
@@ -3,6 +3,8 @@ kind: HelmRelease
 metadata:
   name: &app mealie-postgresql
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: cluster

--- a/cluster/home/memos/app/helmrelease.yaml
+++ b/cluster/home/memos/app/helmrelease.yaml
@@ -4,6 +4,8 @@ kind: HelmRelease
 metadata:
   name: &app memos
 spec:
+  driftDetection:
+    mode: enabled
   interval: 30m
   dependsOn:
     - name: memos-postgresql

--- a/cluster/home/memos/postgres/helmrelease.yaml
+++ b/cluster/home/memos/postgres/helmrelease.yaml
@@ -3,6 +3,8 @@ kind: HelmRelease
 metadata:
   name: &app memos-postgresql
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: cluster

--- a/cluster/home/planka/helmrelease.yaml
+++ b/cluster/home/planka/helmrelease.yaml
@@ -4,6 +4,8 @@ kind: HelmRelease
 metadata:
   name: &app planka
 spec:
+  driftDetection:
+    mode: enabled
   dependsOn:
     - name: planka-postgres
   chart:

--- a/cluster/home/planka/postgres/helmrelease.yaml
+++ b/cluster/home/planka/postgres/helmrelease.yaml
@@ -4,6 +4,8 @@ kind: HelmRelease
 metadata:
   name: planka-postgres
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: cluster

--- a/cluster/identity/authentik/helmrelease.yaml
+++ b/cluster/identity/authentik/helmrelease.yaml
@@ -4,6 +4,8 @@ metadata:
   name: authentik
   namespace: identity
 spec:
+  driftDetection:
+    mode: enabled
   interval: 5m
   dependsOn:
     - name: authentik-postgres

--- a/cluster/identity/authentik/postgres/helmrelease.yaml
+++ b/cluster/identity/authentik/postgres/helmrelease.yaml
@@ -5,6 +5,8 @@ metadata:
   name: authentik-postgres
   namespace: identity
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: cluster

--- a/cluster/internal/node-feature-discovery/helmrelease.yaml
+++ b/cluster/internal/node-feature-discovery/helmrelease.yaml
@@ -5,6 +5,8 @@ metadata:
   name: node-feature-discovery
   namespace: internal
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: node-feature-discovery

--- a/cluster/internal/renovate/helmrelease.yaml
+++ b/cluster/internal/renovate/helmrelease.yaml
@@ -5,6 +5,8 @@ metadata:
   name: renovate
   namespace: internal
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: renovate

--- a/cluster/kube-system/democratic-csi/freenas-iscsi.yaml
+++ b/cluster/kube-system/democratic-csi/freenas-iscsi.yaml
@@ -4,6 +4,8 @@ metadata:
   name: freenas-iscsi
   namespace: kube-system
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: democratic-csi

--- a/cluster/kube-system/democratic-csi/freenas-nfs.yaml
+++ b/cluster/kube-system/democratic-csi/freenas-nfs.yaml
@@ -4,6 +4,8 @@ metadata:
   name: freenas-nfs
   namespace: kube-system
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: democratic-csi

--- a/cluster/kube-system/intel-device-plugin-operator/app/helmrelease.yaml
+++ b/cluster/kube-system/intel-device-plugin-operator/app/helmrelease.yaml
@@ -6,6 +6,8 @@ metadata:
   name: intel-device-plugin-operator
   namespace: kube-system
 spec:
+  driftDetection:
+    mode: enabled
   interval: 1h
   chart:
     spec:

--- a/cluster/kube-system/intel-device-plugin-operator/gpu/helmrelease.yaml
+++ b/cluster/kube-system/intel-device-plugin-operator/gpu/helmrelease.yaml
@@ -6,6 +6,8 @@ metadata:
   name: intel-device-plugin-gpu
   namespace: kube-system
 spec:
+  driftDetection:
+    mode: enabled
   interval: 1h
   install:
     remediation:

--- a/cluster/kube-system/sealed-secrets/helmrelease.yaml
+++ b/cluster/kube-system/sealed-secrets/helmrelease.yaml
@@ -4,6 +4,8 @@ metadata:
   name: sealed-secrets
   namespace: kube-system
 spec:
+  driftDetection:
+    mode: enabled
   interval: 5m
   install:
     remediation:

--- a/cluster/media/immich/helmrelease.yaml
+++ b/cluster/media/immich/helmrelease.yaml
@@ -5,6 +5,8 @@ metadata:
   name: immich
   namespace: media
 spec:
+  driftDetection:
+    mode: enabled
   dependsOn:
     - name: immich-postgres
   chart:

--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -4,6 +4,8 @@ metadata:
   name: &app immich-postgres
   namespace: media
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: cluster

--- a/cluster/media/jellyfin/helmrelease.yaml
+++ b/cluster/media/jellyfin/helmrelease.yaml
@@ -6,6 +6,8 @@ metadata:
   name: jellyfin
   namespace: media
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: app-template

--- a/cluster/network/coredns/helmrelease.yaml
+++ b/cluster/network/coredns/helmrelease.yaml
@@ -4,6 +4,8 @@ metadata:
   name: coredns-primary
   namespace: network
 spec:
+  driftDetection:
+    mode: enabled
   interval: 5m
   install:
     remediation:
@@ -80,6 +82,8 @@ metadata:
   name: coredns-secondary
   namespace: network
 spec:
+  driftDetection:
+    mode: enabled
   interval: 5m
   install:
     remediation:

--- a/cluster/network/external-dns/helmrelease.yaml
+++ b/cluster/network/external-dns/helmrelease.yaml
@@ -4,6 +4,8 @@ metadata:
   name: external-dns
   namespace: network
 spec:
+  driftDetection:
+    mode: enabled
   interval: 5m
   install:
     remediation:

--- a/cluster/network/ingress-nginx/helmrelease.yaml
+++ b/cluster/network/ingress-nginx/helmrelease.yaml
@@ -4,6 +4,8 @@ metadata:
   name: ingress-nginx
   namespace: network
 spec:
+  driftDetection:
+    mode: enabled
   interval: 30m
   install:
     remediation:

--- a/cluster/network/metallb/helmrelease.yaml
+++ b/cluster/network/metallb/helmrelease.yaml
@@ -4,6 +4,8 @@ metadata:
   name: metallb
   namespace: network
 spec:
+  driftDetection:
+    mode: enabled
   interval: 5m
   install:
     remediation:

--- a/cluster/system-upgrade/helmrelease.yaml
+++ b/cluster/system-upgrade/helmrelease.yaml
@@ -4,6 +4,8 @@ metadata:
   name: system-upgrade-controller
   namespace: system-upgrade
 spec:
+  driftDetection:
+    mode: enabled
   chart:
     spec:
       chart: app-template


### PR DESCRIPTION
## Summary

- Flux drift detection was not enabled on any HelmRelease — manual `kubectl edit` or emergency patches (common during recovery events) are silently ignored and never reconciled back to GitOps state
- Adds `driftDetection: mode: enabled` to all 29 HelmReleases so Flux detects and corrects any out-of-band changes

## Test plan

- [ ] Flux reconciles all HelmReleases successfully after merge
- [ ] Make a test `kubectl edit` on a deployment and verify Flux reverts it within one reconcile interval