### PR TITLE
fix: add write permissions to renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Run Renovate


### PR DESCRIPTION
`github.token` defaults to read-only; Renovate needs `contents: write` and `pull-requests: write` to create branches and open PRs.