### PR TITLE
fix: set RENOVATE_REPOSITORIES so renovate knows which repo to scan

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Run Renovate

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -17,3 +17,5 @@ jobs:
         uses: renovatebot/github-action@v46.1.15
         with:
           token: ${{ github.token }}
+        env:
+          RENOVATE_REPOSITORIES: corylwtsn/k8s-gitops


### PR DESCRIPTION
Without this, Renovate logs `No repositories found` and exits without doing anything.