### PR TITLE
fix: add issues:write permission for renovate dependency dashboard

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
       - name: Run Renovate


### PR DESCRIPTION
Renovate needs `issues: write` to create and update the Dependency Dashboard issue. Without it, every run logs `Could not ensure issue: integration-unauthorized`.