### PR TITLE
fix: update sealed-secrets helm repo URL

### DIFF
--- a/cluster/flux-system/helm-chart-repos/sealed-secrets.yaml
+++ b/cluster/flux-system/helm-chart-repos/sealed-secrets.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: flux-system
 spec:
   interval: 24h
-  url: https://bitnami-labs.github.io/sealed-secrets
+  url: https://bitnami.github.io/sealed-secrets
   timeout: 3m


### PR DESCRIPTION
The sealed-secrets project migrated from `github.com/bitnami-labs` to `github.com/bitnami`. The old GitHub Pages URL (`bitnami-labs.github.io/sealed-secrets`) now returns 404, breaking both Flux reconciliation and Renovate chart lookups.

New URL: `https://bitnami.github.io/sealed-secrets`

Chart version stays at 2.18.6 — no values changes needed.