### PR TITLE
feat: migrate system-upgrade-controller to app-template v5

### DIFF
--- a/cluster/system-upgrade/helmrelease.yaml
+++ b/cluster/system-upgrade/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 3.7.1
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
@@ -28,6 +28,8 @@ spec:
       system-upgrade-controller:
         replicas: 2
         strategy: RollingUpdate
+        serviceAccount:
+          identifier: system-upgrade-controller
         pod:
           securityContext:
             runAsUser: 65534
@@ -70,5 +72,6 @@ spec:
                 drop:
                   - ALL
     serviceAccount:
-      create: true
-      name: system-upgrade-controller
+      system-upgrade-controller:
+        enabled: true
+        forceRename: system-upgrade-controller


### PR DESCRIPTION
Migrates system-upgrade-controller from app-template 3.7.1 to 5.0.1.

The only breaking change in v5 for this chart is the `serviceAccount` structure:

- **Before (v3):** `serviceAccount: {create: true, name: system-upgrade-controller}`
- **After (v5):** named dict under `serviceAccount:`, referenced in the controller via `serviceAccount.identifier`

`forceRename` ensures the ServiceAccount keeps the exact name `system-upgrade-controller` that the existing ClusterRoleBindings reference.

All other values (`pod`, `tolerations`, `securityContext`, `containers`) are unchanged — those keys are compatible across v3→v5.

Closes #1963.