### PR TITLE
fix: add security-events:read permission for renovate vulnerability alerts

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,6 +12,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      security-events: read
     steps:
       - uses: actions/checkout@v4
       - name: Run Renovate

--- a/cluster/system-upgrade/helmrelease.yaml
+++ b/cluster/system-upgrade/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 3.7.1
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
@@ -28,6 +28,8 @@ spec:
       system-upgrade-controller:
         replicas: 2
         strategy: RollingUpdate
+        serviceAccount:
+          identifier: system-upgrade-controller
         pod:
           securityContext:
             runAsUser: 65534
@@ -70,5 +72,6 @@ spec:
                 drop:
                   - ALL
     serviceAccount:
-      create: true
-      name: system-upgrade-controller
+      system-upgrade-controller:
+        enabled: true
+        forceRename: system-upgrade-controller


### PR DESCRIPTION
Renovate logs `Cannot access vulnerability alerts` on every run due to the `security:openssf-scorecard` preset in `renovate.json`. Adding `security-events: read` grants the token access.