### PR TITLE
fix: remove security:openssf-scorecard preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,7 @@
   "extends": [
     "config:best-practices",
     "docker:enableMajor",
-    "security:openssf-scorecard",
-    ":semanticCommits",
+":semanticCommits",
     ":timezone(America/New_York)"
   ],
   "flux": {


### PR DESCRIPTION
The `security:openssf-scorecard` preset enables vulnerability alert checks that require a PAT with `security_events` scope. The `github.token` used in Actions cannot access Dependabot vulnerability alerts regardless of workflow permissions, producing a persistent WARN on every run.

Removing the preset stops the warning. Vulnerability scanning can be re-enabled later if a PAT is added.