### PR TITLE
fix: disable vulnerability alerts in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,10 @@
   "extends": [
     "config:best-practices",
     "docker:enableMajor",
-":semanticCommits",
+    ":semanticCommits",
     ":timezone(America/New_York)"
   ],
+  "enableVulnerabilityAlerts": false,
   "flux": {
     "managerFilePatterns": [
       "/(^|/)cluster/.+\\.ya?ml$/"


### PR DESCRIPTION
\`config:best-practices\` enables \`enableVulnerabilityAlerts\` by default. The \`github.token\` cannot access Dependabot vulnerability alerts regardless of workflow permissions, so this logs a WARN on every run. Explicitly disabling it.

Also fixes indentation glitch left by the previous squash merge.