### PR TITLE
fix: disable osv vulnerability alerts (incompatible with github.token)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     ":semanticCommits",
     ":timezone(America/New_York)"
   ],
-  "enableVulnerabilityAlerts": false,
+  "osvVulnerabilityAlerts": false,
   "flux": {
     "managerFilePatterns": [
       "/(^|/)cluster/.+\\.ya?ml$/"


### PR DESCRIPTION
`config:best-practices` enables `osvVulnerabilityAlerts` which requires Dependabot API access. The `github.token` can't access this regardless of permissions. Sets `osvVulnerabilityAlerts: false` to suppress the warning.

Previous attempt used the non-existent `enableVulnerabilityAlerts` key which broke config validation.