### PR TITLE
fix: upgrade security-events to write for vulnerability alert access

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      security-events: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
       - name: Run Renovate


### PR DESCRIPTION
Renovate calls the GitHub vulnerability alerts API during repo init. `security-events: read` isn't sufficient — trying `write`.