### PR TITLE
fix: disable vulnerabilityAlerts in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,9 @@
     ":semanticCommits",
     ":timezone(America/New_York)"
   ],
-  "osvVulnerabilityAlerts": false,
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
   "flux": {
     "managerFilePatterns": [
       "/(^|/)cluster/.+\\.ya?ml$/"


### PR DESCRIPTION
Use the correct `vulnerabilityAlerts.enabled: false` config per the Renovate docs. Also removes the now-unnecessary `osvVulnerabilityAlerts: false` that was replaced by this.