### PR TITLE
fix: add HelmRelease to Flux Discord alert sources

### DIFF
--- a/cluster/media/jellyfin/helmrelease.yaml
+++ b/cluster/media/jellyfin/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
         tls:
           - hosts:
               - watch.internal.wat.sn
-            secretName: jellfyin-ingress-cert
+            secretName: jellyfin-ingress-cert
     persistence:
       config:
         existingClaim: jellyfin-config


### PR DESCRIPTION
Flux alert events only covered GitRepository and Kustomization — HelmRelease failures (the most common failure mode) were completely silent. This adds HelmRelease to the Discord alert event sources.