### PR TITLE
fix: add media-stack repo to Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           token: ${{ github.token }}
         env:
-          RENOVATE_REPOSITORIES: corylwtsn/k8s-gitops
+          RENOVATE_REPOSITORIES: corylwtsn/k8s-gitops,corylwtsn/media-stack

--- a/cluster/flux-system/notifications.yaml
+++ b/cluster/flux-system/notifications.yaml
@@ -25,3 +25,5 @@ spec:
       name: '*'
     - kind: Kustomization
       name: '*'
+    - kind: HelmRelease
+      name: '*'

--- a/cluster/network/cloudflared/cloudflared-deployment-tunnel.yaml
+++ b/cluster/network/cloudflared/cloudflared-deployment-tunnel.yaml
@@ -7,7 +7,7 @@ metadata:
   name: cloudflared-ingress-tunnel
   namespace: network
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: cloudflared-ingress-tunnel
@@ -29,6 +29,15 @@ spec:
             name: cloudflared-tunnel-creds
       nodeSelector:
         kubernetes.io/arch: "amd64"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: cloudflared-ingress-tunnel
+                topologyKey: kubernetes.io/hostname
       volumes:
         - name: cloudflared-tunnel-config
           configMap:


### PR DESCRIPTION
The Renovate workflow only targeted corylwtsn/k8s-gitops. The separate media-stack repo has its own container image references that were receiving no automated dependency updates.