### PR TITLE
fix: correct Jellyfin TLS secret name typo

### DIFF
--- a/cluster/flux-system/notifications.yaml
+++ b/cluster/flux-system/notifications.yaml
@@ -25,3 +25,5 @@ spec:
       name: '*'
     - kind: Kustomization
       name: '*'
+    - kind: HelmRelease
+      name: '*'

--- a/cluster/media/jellyfin/helmrelease.yaml
+++ b/cluster/media/jellyfin/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
         tls:
           - hosts:
               - watch.internal.wat.sn
-            secretName: jellfyin-ingress-cert
+            secretName: jellyfin-ingress-cert
     persistence:
       config:
         existingClaim: jellyfin-config


### PR DESCRIPTION
The TLS secretName had a typo (`jellfyin` instead of `jellyfin`), causing the cert secret reference to point to a non-existent name.