### PR TITLE
fix: add HelmRelease to Flux Discord alert sources

### DIFF
--- a/cluster/flux-system/notifications.yaml
+++ b/cluster/flux-system/notifications.yaml
@@ -25,3 +25,5 @@ spec:
       name: '*'
     - kind: Kustomization
       name: '*'
+    - kind: HelmRelease
+      name: '*'


### PR DESCRIPTION
Flux alert events only covered GitRepository and Kustomization — HelmRelease failures (the most common failure mode) were completely silent. This adds HelmRelease to the Discord alert event sources.