### PR TITLE
fix: run Cloudflared tunnel with 2 replicas for HA

### DIFF
--- a/cluster/network/cloudflared/cloudflared-deployment-tunnel.yaml
+++ b/cluster/network/cloudflared/cloudflared-deployment-tunnel.yaml
@@ -7,7 +7,7 @@ metadata:
   name: cloudflared-ingress-tunnel
   namespace: network
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: cloudflared-ingress-tunnel
@@ -29,6 +29,15 @@ spec:
             name: cloudflared-tunnel-creds
       nodeSelector:
         kubernetes.io/arch: "amd64"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: cloudflared-ingress-tunnel
+                topologyKey: kubernetes.io/hostname
       volumes:
         - name: cloudflared-tunnel-config
           configMap:


### PR DESCRIPTION
All external access (auth, photos, planka, memos, ha, mealie) was routing through a single Cloudflared pod. A pod restart or node drain meant complete external access loss.

This adds a second replica with pod anti-affinity to spread the two pods across different nodes. Cloudflare's tunnel protocol natively handles multiple connectors to the same tunnel.