### PR TITLE
feat: add CI manifest validation with kustomize and kubeconform

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,9 +13,11 @@ jobs:
         uses: imranismail/setup-kustomize@v2
 
       - name: Set up kubeconform
+        env:
+          KUBECONFORM_VERSION: v0.8.0
         run: |
           curl -sSLo /tmp/kubeconform.tar.gz \
-            https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz
+            https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz
           tar -xf /tmp/kubeconform.tar.gz -C /usr/local/bin kubeconform
           chmod +x /usr/local/bin/kubeconform
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,4 +28,5 @@ jobs:
             -ignore-missing-schemas \
             -schema-location default \
             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            -skip SealedSecret,IPAddressPool \
             -summary

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,29 @@
+name: Validate
+
+on:
+  pull_request: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up kustomize
+        uses: imranismail/setup-kustomize@v2
+
+      - name: Set up kubeconform
+        run: |
+          curl -sSLo /tmp/kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz
+          tar -xf /tmp/kubeconform.tar.gz -C /usr/local/bin kubeconform
+          chmod +x /usr/local/bin/kubeconform
+
+      - name: Validate manifests
+        run: |
+          kustomize build ./cluster | kubeconform \
+            -strict \
+            -ignore-missing-schemas \
+            -schema-location default \
+            -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+            -summary


### PR DESCRIPTION
Adds a `validate` workflow that runs on every PR. It builds the full kustomize tree and pipes it through kubeconform with strict validation against Kubernetes core schemas plus the CRDs catalog for Flux, cert-manager, and other custom resources.

`-ignore-missing-schemas` prevents failures for CRDs not yet in the catalog.