### PR TITLE
feat: add yamllint and yaml syntax checks to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,23 @@
 ---
 # See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks\
+# See https://pre-commit.com/hooks.html for more hooks
 fail_fast: false
 repos:
   - repo: https://github.com/k8s-at-home/sops-pre-commit
     rev: v2.0.3
     hooks:
       - id: forbid-secrets
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+        args: [--strict, -d, '{extends: relaxed, rules: {line-length: {max: 200}}}']
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace


### PR DESCRIPTION
Adds local pre-commit hooks to catch issues before they reach CI:
- `yamllint` with relaxed config (line length 200, strict mode)
- `check-yaml` for multi-document YAML syntax validation
- `end-of-file-fixer` and `trailing-whitespace` for consistency

Complements the new CI validation workflow.