### PR TITLE
feat: bump all CNPG clusters to 2 instances for HA

### DIFF
--- a/cluster/home/mealie/database/helmrelease.yaml
+++ b/cluster/home/mealie/database/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
       mode: standalone
 
     cluster:
-      instances: 1
+      instances: 2
       imageName: "ghcr.io/cloudnative-pg/postgresql:16@sha256:4418a66c2232ba0bd63dd6c7a98ee401bcac340efbb5f380f8879d004654a7d3"
       storage:
         size: 10Gi

--- a/cluster/home/memos/postgres/helmrelease.yaml
+++ b/cluster/home/memos/postgres/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
       mode: standalone
 
     cluster:
-      instances: 1
+      instances: 2
       imageName: "ghcr.io/cloudnative-pg/postgresql:16@sha256:4418a66c2232ba0bd63dd6c7a98ee401bcac340efbb5f380f8879d004654a7d3"
       storage:
         size: 10Gi

--- a/cluster/home/planka/postgres/helmrelease.yaml
+++ b/cluster/home/planka/postgres/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
       mode: standalone
 
     cluster:
-      instances: 1
+      instances: 2
       storage:
         size: 10Gi
         storageClass: freenas-nfs-csi

--- a/cluster/identity/authentik/postgres/helmrelease.yaml
+++ b/cluster/identity/authentik/postgres/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
       mode: standalone
 
     cluster:
-      instances: 1
+      instances: 2
       storage:
         size: 8Gi
         storageClass: freenas-nfs-csi

--- a/cluster/media/immich/postgres/helmrelease.yaml
+++ b/cluster/media/immich/postgres/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
       mode: standalone
 
     cluster:
-      instances: 1
+      instances: 2
       imageName: "ghcr.io/tensorchord/cloudnative-vectorchord:18-1.1.1@sha256:392b53675b403d6a2c72b673cc488a7c272514755dd818c622fb9ce4665193c4"
       storage:
         size: 5Gi


### PR DESCRIPTION
Adds a hot streaming standby to all five CNPG clusters. CNPG handles standby provisioning, WAL streaming, and automatic promotion on primary failure.

| Cluster   | App      | Extra NFS storage |
|-----------|----------|-------------------|
| Authentik | SSO/auth | 8Gi               |
| Immich    | Photos   | 5Gi               |
| Mealie    | Recipes  | 10Gi              |
| Memos     | Notes    | 10Gi              |
| Planka    | Kanban   | 10Gi              |

**After merge:** confirm with `kubectl get clusters -A` — each cluster should show `2/2` instances ready.