### PR TITLE
feat: add kube-prometheus-stack for metrics and alerting

### DIFF
--- a/cluster/flux-system/helm-chart-repos/kustomization.yaml
+++ b/cluster/flux-system/helm-chart-repos/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - authentik.yaml
+  - prometheus-community.yaml
   - bitnami.yaml
   - bjw-s.yaml
   - cloudnative-pg.yaml

--- a/cluster/flux-system/helm-chart-repos/prometheus-community.yaml
+++ b/cluster/flux-system/helm-chart-repos/prometheus-community.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://prometheus-community.github.io/helm-charts
+  timeout: 3m

--- a/cluster/observability/kube-prometheus-stack/external-secret-discord.yaml
+++ b/cluster/observability/kube-prometheus-stack/external-secret-discord.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-discord
+  namespace: observability
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: alertmanager-discord
+    creationPolicy: Owner
+    deletionPolicy: "Delete"
+    template:
+      engineVersion: v2
+      data:
+        webhook-url: '{{ index . "webhook-url" }}'
+        critical-webhook-url: '{{ index . "critical-webhook-url" }}'
+  dataFrom:
+    - extract:
+        key: alertmanager-discord

--- a/cluster/observability/kube-prometheus-stack/external-secret-grafana-admin.yaml
+++ b/cluster/observability/kube-prometheus-stack/external-secret-grafana-admin.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-admin
+  namespace: observability
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: grafana-admin
+    creationPolicy: Owner
+    deletionPolicy: "Delete"
+    template:
+      engineVersion: v2
+      data:
+        admin-user: "{{ .username }}"
+        admin-password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: grafana-admin

--- a/cluster/observability/kube-prometheus-stack/external-secret-grafana-oidc.yaml
+++ b/cluster/observability/kube-prometheus-stack/external-secret-grafana-oidc.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-oidc
+  namespace: observability
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: grafana-oidc
+    creationPolicy: Owner
+    deletionPolicy: "Delete"
+    template:
+      engineVersion: v2
+      data:
+        GF_AUTH_GENERIC_OAUTH_CLIENT_ID: '{{ index . "client-id" }}'
+        GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: '{{ index . "client-secret" }}'
+  dataFrom:
+    - extract:
+        key: grafana-oidc

--- a/cluster/observability/kube-prometheus-stack/external-secret-healthchecks.yaml
+++ b/cluster/observability/kube-prometheus-stack/external-secret-healthchecks.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-healthchecks
+  namespace: observability
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: alertmanager-healthchecks
+    creationPolicy: Owner
+    deletionPolicy: "Delete"
+    template:
+      engineVersion: v2
+      data:
+        ping-url: '{{ index . "ping-url" }}'
+  dataFrom:
+    - extract:
+        key: alertmanager-healthchecks

--- a/cluster/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/cluster/observability/kube-prometheus-stack/helmrelease.yaml
@@ -1,0 +1,157 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: observability
+spec:
+  interval: 1h
+  driftDetection:
+    mode: enabled
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      version: 86.2.3
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+      interval: 24h
+  values:
+    # ── Prometheus ────────────────────────────────────────────────────────────
+    prometheus:
+      prometheusSpec:
+        nodeSelector:
+          kubernetes.io/arch: amd64
+        retention: 14d
+        retentionSize: 15GB
+        # Tuned for NFS: tolerate 150s of NAS blip before killing pod mid-WAL-recovery
+        livenessProbeFailureThreshold: 10
+        livenessProbePeriodSeconds: 15
+        livenessProbeTimeoutSeconds: 5
+        # Discover monitors/rules/probes in all namespaces
+        podMonitorSelectorNilUsesHelmValues: false
+        serviceMonitorSelectorNilUsesHelmValues: false
+        probeSelectorNilUsesHelmValues: false
+        ruleSelectorNilUsesHelmValues: false
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: freenas-nfs-csi
+              accessModes: [ReadWriteOnce]
+              resources:
+                requests:
+                  storage: 25Gi
+
+    # ── Grafana ───────────────────────────────────────────────────────────────
+    grafana:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      # Admin credentials from ESO — chart looks for admin-user and admin-password keys
+      admin:
+        existingSecret: grafana-admin
+        userKey: admin-user
+        passwordKey: admin-password
+      # OIDC client ID/secret injected as GF_AUTH_GENERIC_OAUTH_CLIENT_* env vars
+      envFromSecret: grafana-oidc
+      persistence:
+        enabled: true
+        storageClassName: freenas-nfs-csi
+        size: 2Gi
+      ingress:
+        enabled: false
+      sidecar:
+        dashboards:
+          enabled: true
+          searchNamespace: ALL
+        datasources:
+          enabled: true
+          searchNamespace: ALL
+      "grafana.ini":
+        server:
+          root_url: https://grafana.internal.wat.sn
+        auth.generic_oauth:
+          enabled: true
+          name: Authentik
+          scopes: openid profile email goauthentik.io/userinfo
+          auth_url: https://auth.wat.sn/application/o/grafana/authorize/
+          token_url: https://auth.wat.sn/application/o/grafana/token/
+          api_url: https://auth.wat.sn/application/o/userinfo/
+          # GF_AUTH_GENERIC_OAUTH_CLIENT_ID and _CLIENT_SECRET come from envFromSecret
+          role_attribute_path: contains(groups[*], 'grafana-admins') && 'Admin' || 'Viewer'
+          allow_sign_up: true
+        users:
+          auto_assign_org_role: Viewer
+
+    # ── Alertmanager ──────────────────────────────────────────────────────────
+    alertmanager:
+      alertmanagerSpec:
+        nodeSelector:
+          kubernetes.io/arch: amd64
+        replicas: 1
+        secrets:
+          - alertmanager-discord
+          - alertmanager-healthchecks
+        storage:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: freenas-nfs-csi
+              accessModes: [ReadWriteOnce]
+              resources:
+                requests:
+                  storage: 1Gi
+      config:
+        global:
+          resolve_timeout: 5m
+        inhibit_rules:
+          - source_matchers:
+              - severity = critical
+            target_matchers:
+              - severity = warning
+            equal: [alertname, namespace]
+        route:
+          receiver: default
+          group_by: [alertname, namespace]
+          group_wait: 30s
+          group_interval: 5m
+          repeat_interval: 12h
+          routes:
+            - receiver: deadman
+              matchers:
+                - name: alertname
+                  value: Watchdog
+              group_wait: 0s
+              group_interval: 2m
+              repeat_interval: 2m
+            - receiver: critical
+              matchers:
+                - name: severity
+                  value: critical
+        receivers:
+          - name: default
+            discord_configs:
+              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord/webhook-url
+          - name: critical
+            discord_configs:
+              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord/critical-webhook-url
+          - name: deadman
+            webhook_configs:
+              - url_file: /etc/alertmanager/secrets/alertmanager-healthchecks/ping-url
+                send_resolved: false
+
+    # ── Node exporter ─────────────────────────────────────────────────────────
+    # Explicit toleration so node-exporter runs on the 3 arm64 control-plane RPi nodes
+    prometheus-node-exporter:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule

--- a/cluster/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/cluster/observability/kube-prometheus-stack/helmrelease.yaml
@@ -114,10 +114,15 @@ spec:
           resolve_timeout: 5m
         inhibit_rules:
           - source_matchers:
-              - severity = critical
+              - severity = "critical"
             target_matchers:
-              - severity = warning
+              - severity = "warning"
             equal: [alertname, namespace]
+          - source_matchers:
+              - alertname = "PVCUsageCritical"
+            target_matchers:
+              - alertname = "PVCUsageWarning"
+            equal: [namespace, persistentvolumeclaim]
         route:
           receiver: default
           group_by: [alertname, namespace]
@@ -127,15 +132,13 @@ spec:
           routes:
             - receiver: deadman
               matchers:
-                - name: alertname
-                  value: Watchdog
+                - alertname = "Watchdog"
               group_wait: 0s
               group_interval: 2m
               repeat_interval: 2m
             - receiver: critical
               matchers:
-                - name: severity
-                  value: critical
+                - severity = "critical"
         receivers:
           - name: default
             discord_configs:

--- a/cluster/observability/kube-prometheus-stack/ingress.yaml
+++ b/cluster/observability/kube-prometheus-stack/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana
+  namespace: observability
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: &host grafana.internal.wat.sn
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kube-prometheus-stack-grafana
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - *host
+      secretName: grafana-cert

--- a/cluster/observability/kube-prometheus-stack/kustomization.yaml
+++ b/cluster/observability/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - external-secret-discord.yaml
+  - external-secret-healthchecks.yaml
+  - external-secret-grafana-oidc.yaml
+  - external-secret-grafana-admin.yaml
+  - helmrelease.yaml
+  - ingress.yaml
+  - prometheusrule-pvc.yaml

--- a/cluster/observability/kube-prometheus-stack/prometheusrule-pvc.yaml
+++ b/cluster/observability/kube-prometheus-stack/prometheusrule-pvc.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pvc-usage
+  namespace: observability
+spec:
+  groups:
+    - name: pvc.rules
+      rules:
+        - alert: PVCUsageWarning
+          expr: |
+            (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) > 0.85
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "PVC {{ $labels.persistentvolumeclaim }} above 85%"
+            description: "PVC {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is {{ $value | humanizePercentage }} full."
+        - alert: PVCUsageCritical
+          expr: |
+            (kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) > 0.90
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "PVC {{ $labels.persistentvolumeclaim }} above 90%"
+            description: "PVC {{ $labels.persistentvolumeclaim }} in namespace {{ $labels.namespace }} is {{ $value | humanizePercentage }} full."

--- a/cluster/observability/kustomization.yaml
+++ b/cluster/observability/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - kube-prometheus-stack


### PR DESCRIPTION
## Summary

- Deploys kube-prometheus-stack v86.2.3 (Prometheus, Grafana, Alertmanager, node-exporter, kube-state-metrics) into the `observability` namespace
- Grafana exposed at `grafana.internal.wat.sn` with Authentik OIDC; `grafana-users` group gates access, `grafana-admins` group maps to Admin role
- Alertmanager routes warning alerts to `#alerts` and critical to `#alerts-critical` via Discord; Watchdog pings Healthchecks.io every 2m as a deadman switch
- Custom PrometheusRule fires at PVC ≥85% (warning) and ≥90% (critical) — tighter than the default 97% threshold
- All secrets via ESO from 1Password vault `k8s-home`

## Pre-merge checklist

- [x] 1Password items exist: `alertmanager-discord`, `alertmanager-healthchecks`, `grafana-oidc`, `grafana-admin`
- [x] Authentik: OIDC provider + application (slug `grafana`) created, bound to `grafana-users` group; `grafana-admins` group exists
- [x] Healthchecks.io check created with 5-minute grace period

## Test plan

- [ ] KPS CRDs land cleanly (`kubectl get crd | grep monitoring.coreos.com`)
- [ ] All four ExternalSecrets sync (`kubectl get externalsecret -n observability`)
- [ ] Prometheus pod Running, PVC bound on `freenas-nfs-csi`
- [ ] Grafana pod Running, reachable at `https://grafana.internal.wat.sn`
- [ ] OIDC login works for a `grafana-users` member; role is Viewer
- [ ] OIDC login works for a `grafana-admins` member; role is Admin
- [ ] Fallback admin login works (credentials from 1Password `grafana-admin`)
- [ ] Watchdog alert appears in Alertmanager UI and Healthchecks.io receives pings
- [ ] Test alert routes to `#alerts` (warning) and `#alerts-critical` (critical)
- [ ] No ingress exists for Prometheus or Alertmanager (`kubectl get ingress -n observability`)
- [ ] node-exporter DaemonSet has pods on all 6 nodes including RPi control-plane