### PR TITLE
fix: use configSecret for Alertmanager to avoid operator validation

### DIFF
--- a/cluster/observability/kube-prometheus-stack/external-secret-alertmanager-config.yaml
+++ b/cluster/observability/kube-prometheus-stack/external-secret-alertmanager-config.yaml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-config
+  namespace: observability
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: alertmanager-config
+    creationPolicy: Owner
+    deletionPolicy: "Delete"
+    template:
+      engineVersion: v2
+      data:
+        alertmanager.yaml: |
+          global:
+            resolve_timeout: 5m
+          inhibit_rules:
+            - source_matchers:
+                - severity = "critical"
+              target_matchers:
+                - severity = "warning"
+              equal: [alertname, namespace]
+            - source_matchers:
+                - alertname = "PVCUsageCritical"
+              target_matchers:
+                - alertname = "PVCUsageWarning"
+              equal: [namespace, persistentvolumeclaim]
+          route:
+            receiver: default
+            group_by: [alertname, namespace]
+            group_wait: 30s
+            group_interval: 5m
+            repeat_interval: 12h
+            routes:
+              - receiver: deadman
+                matchers:
+                  - alertname = "Watchdog"
+                group_wait: 0s
+                group_interval: 2m
+                repeat_interval: 2m
+              - receiver: critical
+                matchers:
+                  - severity = "critical"
+          receivers:
+            - name: default
+              discord_configs:
+                - webhook_url: '{{ index . "webhook-url" }}'
+            - name: critical
+              discord_configs:
+                - webhook_url: '{{ index . "critical-webhook-url" }}'
+            - name: deadman
+              webhook_configs:
+                - url: '{{ index . "ping-url" }}'
+                  send_resolved: false
+  dataFrom:
+    - extract:
+        key: alertmanager-discord
+    - extract:
+        key: alertmanager-healthchecks

--- a/cluster/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/cluster/observability/kube-prometheus-stack/helmrelease.yaml
@@ -98,9 +98,7 @@ spec:
         nodeSelector:
           kubernetes.io/arch: amd64
         replicas: 1
-        secrets:
-          - alertmanager-discord
-          - alertmanager-healthchecks
+        configSecret: alertmanager-config
         storage:
           volumeClaimTemplate:
             spec:
@@ -109,48 +107,6 @@ spec:
               resources:
                 requests:
                   storage: 1Gi
-      config:
-        global:
-          resolve_timeout: 5m
-        inhibit_rules:
-          - source_matchers:
-              - severity = "critical"
-            target_matchers:
-              - severity = "warning"
-            equal: [alertname, namespace]
-          - source_matchers:
-              - alertname = "PVCUsageCritical"
-            target_matchers:
-              - alertname = "PVCUsageWarning"
-            equal: [namespace, persistentvolumeclaim]
-        route:
-          receiver: default
-          group_by: [alertname, namespace]
-          group_wait: 30s
-          group_interval: 5m
-          repeat_interval: 12h
-          routes:
-            - receiver: deadman
-              matchers:
-                - alertname = "Watchdog"
-              group_wait: 0s
-              group_interval: 2m
-              repeat_interval: 2m
-            - receiver: critical
-              matchers:
-                - severity = "critical"
-        receivers:
-          - name: default
-            discord_configs:
-              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord/webhook-url
-          - name: critical
-            discord_configs:
-              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord/critical-webhook-url
-          - name: deadman
-            webhook_configs:
-              - url_file: /etc/alertmanager/secrets/alertmanager-healthchecks/ping-url
-                send_resolved: false
-
     # ── Node exporter ─────────────────────────────────────────────────────────
     # Explicit toleration so node-exporter runs on the 3 arm64 control-plane RPi nodes
     prometheus-node-exporter:

--- a/cluster/observability/kube-prometheus-stack/kustomization.yaml
+++ b/cluster/observability/kube-prometheus-stack/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - external-secret-alertmanager-config.yaml
   - external-secret-discord.yaml
   - external-secret-healthchecks.yaml
   - external-secret-grafana-oidc.yaml


### PR DESCRIPTION
## Problem

Alertmanager v0.33.0 (shipped by KPS 86.2.3) does not support `webhook_url_file` in `discord_configs`. The Prometheus Operator validates the config through its internal Go types before creating the StatefulSet, causing reconciliation to fail with:

```
provision alertmanager configuration: failed to initialize from secret: yaml: unmarshal errors:
  line 20: field webhook_url_file not found in type alertmanager.discordConfig
```

## Fix

- Add `external-secret-alertmanager-config.yaml`: ESO merges `alertmanager-discord` and `alertmanager-healthchecks` from 1Password into a single `alertmanager.yaml` secret with real `webhook_url` values embedded
- Switch `alertmanagerSpec.configSecret: alertmanager-config` so the operator uses that secret directly
- Remove the `alertmanager.config` block and `alertmanagerSpec.secrets` mounts from the HelmRelease — no longer needed

Webhook URLs remain out of git; sourced from 1Password via ESO.

## Test plan

- [ ] `alertmanager-config` ExternalSecret syncs
- [ ] Alertmanager StatefulSet created and pod reaches Running
- [ ] Alertmanager PVC bound on `freenas-nfs-csi`
- [ ] Watchdog alert visible in Alertmanager UI
- [ ] Healthchecks.io receives pings within 2 minutes
- [ ] Test warning alert routes to `#alerts`
- [ ] Test critical alert routes to `#alerts-critical`