### PR TITLE
feat: add internal ingress for Prometheus and Alertmanager

### DIFF
--- a/cluster/observability/kube-prometheus-stack/ingress.yaml
+++ b/cluster/observability/kube-prometheus-stack/ingress.yaml
@@ -22,3 +22,53 @@ spec:
     - hosts:
         - *host
       secretName: grafana-cert
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus
+  namespace: observability
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: &host prometheus.internal.wat.sn
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kube-prometheus-stack-prometheus
+                port:
+                  number: 9090
+  tls:
+    - hosts:
+        - *host
+      secretName: prometheus-cert
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alertmanager
+  namespace: observability
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: &host alertmanager.internal.wat.sn
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kube-prometheus-stack-alertmanager
+                port:
+                  number: 9093
+  tls:
+    - hosts:
+        - *host
+      secretName: alertmanager-cert


### PR DESCRIPTION
## Summary

Adds internal-only ingress for Prometheus and Alertmanager alongside the existing Grafana ingress.

- `https://prometheus.internal.wat.sn` — needed for Grafana→Prometheus deep links
- `https://alertmanager.internal.wat.sn` — useful for silence management without port-forwarding

Both are internal-only (`*.internal.wat.sn`), no public exposure. No auth, but acceptable on a homelab internal network.

## Test plan

- [ ] `prometheus-cert` and `alertmanager-cert` issued by cert-manager
- [ ] `https://prometheus.internal.wat.sn` loads Prometheus UI
- [ ] `https://alertmanager.internal.wat.sn` loads Alertmanager UI