### PR TITLE
fix: use username/password fields for grafana-oidc ExternalSecret

### DIFF
--- a/cluster/observability/kube-prometheus-stack/external-secret-grafana-oidc.yaml
+++ b/cluster/observability/kube-prometheus-stack/external-secret-grafana-oidc.yaml
@@ -15,8 +15,8 @@ spec:
     template:
       engineVersion: v2
       data:
-        GF_AUTH_GENERIC_OAUTH_CLIENT_ID: '{{ index . "client-id" }}'
-        GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: '{{ index . "client-secret" }}'
+        GF_AUTH_GENERIC_OAUTH_CLIENT_ID: "{{ .username }}"
+        GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET: "{{ .password }}"
   dataFrom:
     - extract:
         key: grafana-oidc


### PR DESCRIPTION
The 1Password `grafana-oidc` item stores credentials in standard `username`/`password` fields. The ESO template was looking for `client-id`/`client-secret` custom fields which don't exist, resulting in empty env vars and `client_id=some_id` placeholder in the Authentik redirect URL.