### PR TITLE
fix: update Grafana OIDC URLs for Authentik 2026.x

### DIFF
--- a/cluster/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/cluster/observability/kube-prometheus-stack/helmrelease.yaml
@@ -83,8 +83,8 @@ spec:
           enabled: true
           name: Authentik
           scopes: openid profile email goauthentik.io/userinfo
-          auth_url: https://auth.wat.sn/application/o/grafana/authorize/
-          token_url: https://auth.wat.sn/application/o/grafana/token/
+          auth_url: https://auth.wat.sn/application/o/authorize/
+          token_url: https://auth.wat.sn/application/o/token/
           api_url: https://auth.wat.sn/application/o/userinfo/
           # GF_AUTH_GENERIC_OAUTH_CLIENT_ID and _CLIENT_SECRET come from envFromSecret
           role_attribute_path: contains(groups[*], 'grafana-admins') && 'Admin' || 'Viewer'


### PR DESCRIPTION
Authentik 2026.x changed OAuth2 endpoint URLs — the application slug is no longer in the authorization/token URL paths. Routes to `/application/o/grafana/authorize/` return 404; the correct global endpoint is `/application/o/authorize/`.