### PR TITLE
fix: wire k3s control plane metrics and silence kube-proxy alert

### DIFF
--- a/cluster/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/cluster/observability/kube-prometheus-stack/helmrelease.yaml
@@ -27,7 +27,6 @@ spec:
         namespace: flux-system
       interval: 24h
   values:
-    # ── Prometheus ────────────────────────────────────────────────────────────
     prometheus:
       prometheusSpec:
         nodeSelector:
@@ -38,7 +37,6 @@ spec:
         livenessProbeFailureThreshold: 10
         livenessProbePeriodSeconds: 15
         livenessProbeTimeoutSeconds: 5
-        # Discover monitors/rules/probes in all namespaces
         podMonitorSelectorNilUsesHelmValues: false
         serviceMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
@@ -52,16 +50,13 @@ spec:
                 requests:
                   storage: 25Gi
 
-    # ── Grafana ───────────────────────────────────────────────────────────────
     grafana:
       nodeSelector:
         kubernetes.io/arch: amd64
-      # Admin credentials from ESO — chart looks for admin-user and admin-password keys
       admin:
         existingSecret: grafana-admin
         userKey: admin-user
         passwordKey: admin-password
-      # OIDC client ID/secret injected as GF_AUTH_GENERIC_OAUTH_CLIENT_* env vars
       envFromSecret: grafana-oidc
       persistence:
         enabled: true
@@ -86,13 +81,11 @@ spec:
           auth_url: https://auth.wat.sn/application/o/authorize/
           token_url: https://auth.wat.sn/application/o/token/
           api_url: https://auth.wat.sn/application/o/userinfo/
-          # GF_AUTH_GENERIC_OAUTH_CLIENT_ID and _CLIENT_SECRET come from envFromSecret
           role_attribute_path: contains(groups[*], 'grafana-admins') && 'Admin' || 'Viewer'
           allow_sign_up: true
         users:
           auto_assign_org_role: Viewer
 
-    # ── Alertmanager ──────────────────────────────────────────────────────────
     alertmanager:
       alertmanagerSpec:
         nodeSelector:
@@ -107,6 +100,7 @@ spec:
               resources:
                 requests:
                   storage: 1Gi
+
     # k3s binds these to 127.0.0.1 by default; requires bind-address=0.0.0.0 in k3s config
     kubeControllerManager:
       endpoints: [10.0.99.50, 10.0.99.51, 10.0.99.52]
@@ -115,8 +109,6 @@ spec:
     kubeProxy:
       enabled: false  # k3s has no kube-proxy
 
-    # ── Node exporter ─────────────────────────────────────────────────────────
-    # Explicit toleration so node-exporter runs on the 3 arm64 control-plane RPi nodes
     prometheus-node-exporter:
       tolerations:
         - key: node-role.kubernetes.io/control-plane

--- a/cluster/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/cluster/observability/kube-prometheus-stack/helmrelease.yaml
@@ -107,6 +107,25 @@ spec:
               resources:
                 requests:
                   storage: 1Gi
+    # ── Control plane component scraping ──────────────────────────────────────
+    # k3s runs controller-manager and scheduler embedded in the server binary.
+    # They bind to 127.0.0.1 by default; bind-address=0.0.0.0 must be set in
+    # /etc/rancher/k3s/config.yaml on each server node + k3s restarted.
+    # Bearer token auth (standard RBAC) works — no authorization-always-allow-paths needed.
+    kubeControllerManager:
+      endpoints:
+        - 10.0.99.50
+        - 10.0.99.51
+        - 10.0.99.52
+    kubeScheduler:
+      endpoints:
+        - 10.0.99.50
+        - 10.0.99.51
+        - 10.0.99.52
+    # k3s has no kube-proxy process — disable the ServiceMonitor and alert entirely
+    kubeProxy:
+      enabled: false
+
     # ── Node exporter ─────────────────────────────────────────────────────────
     # Explicit toleration so node-exporter runs on the 3 arm64 control-plane RPi nodes
     prometheus-node-exporter:

--- a/cluster/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/cluster/observability/kube-prometheus-stack/helmrelease.yaml
@@ -107,24 +107,13 @@ spec:
               resources:
                 requests:
                   storage: 1Gi
-    # ── Control plane component scraping ──────────────────────────────────────
-    # k3s runs controller-manager and scheduler embedded in the server binary.
-    # They bind to 127.0.0.1 by default; bind-address=0.0.0.0 must be set in
-    # /etc/rancher/k3s/config.yaml on each server node + k3s restarted.
-    # Bearer token auth (standard RBAC) works — no authorization-always-allow-paths needed.
+    # k3s binds these to 127.0.0.1 by default; requires bind-address=0.0.0.0 in k3s config
     kubeControllerManager:
-      endpoints:
-        - 10.0.99.50
-        - 10.0.99.51
-        - 10.0.99.52
+      endpoints: [10.0.99.50, 10.0.99.51, 10.0.99.52]
     kubeScheduler:
-      endpoints:
-        - 10.0.99.50
-        - 10.0.99.51
-        - 10.0.99.52
-    # k3s has no kube-proxy process — disable the ServiceMonitor and alert entirely
+      endpoints: [10.0.99.50, 10.0.99.51, 10.0.99.52]
     kubeProxy:
-      enabled: false
+      enabled: false  # k3s has no kube-proxy
 
     # ── Node exporter ─────────────────────────────────────────────────────────
     # Explicit toleration so node-exporter runs on the 3 arm64 control-plane RPi nodes

--- a/cluster/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/cluster/observability/kube-prometheus-stack/helmrelease.yaml
@@ -27,6 +27,7 @@ spec:
         namespace: flux-system
       interval: 24h
   values:
+    # ── Prometheus ────────────────────────────────────────────────────────────
     prometheus:
       prometheusSpec:
         nodeSelector:
@@ -37,6 +38,7 @@ spec:
         livenessProbeFailureThreshold: 10
         livenessProbePeriodSeconds: 15
         livenessProbeTimeoutSeconds: 5
+        # Discover monitors/rules/probes in all namespaces
         podMonitorSelectorNilUsesHelmValues: false
         serviceMonitorSelectorNilUsesHelmValues: false
         probeSelectorNilUsesHelmValues: false
@@ -50,6 +52,7 @@ spec:
                 requests:
                   storage: 25Gi
 
+    # ── Grafana ───────────────────────────────────────────────────────────────
     grafana:
       nodeSelector:
         kubernetes.io/arch: amd64
@@ -86,6 +89,7 @@ spec:
         users:
           auto_assign_org_role: Viewer
 
+    # ── Alertmanager ──────────────────────────────────────────────────────────
     alertmanager:
       alertmanagerSpec:
         nodeSelector:
@@ -109,6 +113,8 @@ spec:
     kubeProxy:
       enabled: false  # k3s has no kube-proxy
 
+    # ── Node exporter ─────────────────────────────────────────────────────────
+    # Explicit toleration so node-exporter runs on the 3 arm64 control-plane RPi nodes
     prometheus-node-exporter:
       tolerations:
         - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
- Point controller-manager and scheduler ServiceMonitors at control plane node IPs — k3s binds these to 127.0.0.1 by default
- Disable kubeProxy — k3s has no kube-proxy process