### PR TITLE
fix: improve Discord alert message formatting

### DIFF
--- a/cluster/observability/kube-prometheus-stack/external-secret-alertmanager-config.yaml
+++ b/cluster/observability/kube-prometheus-stack/external-secret-alertmanager-config.yaml
@@ -49,9 +49,23 @@ spec:
             - name: default
               discord_configs:
                 - webhook_url: '{{ index . "webhook-url" }}'
+                  title: '{{ "{{" }} if eq .Status "firing" {{ "}}" }}🔥 [FIRING:{{ "{{" }} .Alerts.Firing | len {{ "}}" }}]{{ "{{" }} else {{ "}}" }}✅ [RESOLVED]{{ "{{" }} end {{ "}}" }} {{ "{{" }} .GroupLabels.alertname {{ "}}" }}{{ "{{" }} with .GroupLabels.namespace {{ "}}" }} · {{ "{{" }} . {{ "}}" }}{{ "{{" }} end {{ "}}" }}'
+                  message: |
+                    {{ "{{" }} range .Alerts -{{ "}}" }}
+                    **`{{ "{{" }} .Labels.severity | toUpper {{ "}}" }}`**{{ "{{" }} with .Labels.namespace {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}{{ "{{" }} with .Labels.node {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}{{ "{{" }} with .Labels.cnpg_cluster {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} .Annotations.summary {{ "}}" }}
+                    {{ "{{" }} with .Annotations.runbook_url {{ "}}" }}[Runbook]({{ "{{" }} . {{ "}}" }})  {{ "{{" }} end -{{ "}}" }}[Source ↗]({{ "{{" }} .GeneratorURL {{ "}}" }})
+                    {{ "{{" }} end {{ "}}" }}
             - name: critical
               discord_configs:
                 - webhook_url: '{{ index . "critical-webhook-url" }}'
+                  title: '{{ "{{" }} if eq .Status "firing" {{ "}}" }}🚨 [FIRING:{{ "{{" }} .Alerts.Firing | len {{ "}}" }}]{{ "{{" }} else {{ "}}" }}✅ [RESOLVED]{{ "{{" }} end {{ "}}" }} {{ "{{" }} .GroupLabels.alertname {{ "}}" }}{{ "{{" }} with .GroupLabels.namespace {{ "}}" }} · {{ "{{" }} . {{ "}}" }}{{ "{{" }} end {{ "}}" }}'
+                  message: |
+                    {{ "{{" }} range .Alerts -{{ "}}" }}
+                    **`{{ "{{" }} .Labels.severity | toUpper {{ "}}" }}`**{{ "{{" }} with .Labels.namespace {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}{{ "{{" }} with .Labels.node {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}{{ "{{" }} with .Labels.cnpg_cluster {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} .Annotations.summary {{ "}}" }}
+                    {{ "{{" }} with .Annotations.runbook_url {{ "}}" }}[Runbook]({{ "{{" }} . {{ "}}" }})  {{ "{{" }} end -{{ "}}" }}[Source ↗]({{ "{{" }} .GeneratorURL {{ "}}" }})
+                    {{ "{{" }} end {{ "}}" }}
             - name: deadman
               webhook_configs:
                 - url: '{{ index . "ping-url" }}'


### PR DESCRIPTION
## Summary

The default Alertmanager Discord integration dumps every label and the full multi-paragraph annotation description, which is hard to read at a glance.

This PR adds `title` and `message` fields to both Discord receivers:

**Title:**
```
🔥 [FIRING:1] KubeNodeNotReady · observability
✅ [RESOLVED] KubeNodeNotReady · observability
```

**Body:**
```
**`WARNING`** · `observability` · `hp-mini-002`
Node is not ready.
[Source ↗](http://prometheus/...)
```

or with a runbook + CNPG cluster label:
```
**`CRITICAL`** · `identity` · `authentik-postgres-cluster`
CNPG Cluster has no running instances!
[Runbook](https://github.com/...) [Source ↗](http://prometheus/...)
```

Conditional fields (`node`, `cnpg_cluster`) are omitted when not present. Warning receiver uses 🔥, critical uses 🚨.

## Test plan

- [ ] After Flux reconciles the ExternalSecret, check `kubectl -n observability get secret alertmanager-config -o jsonpath='{.data.alertmanager\.yaml}' | base64 -d` to confirm `title` and `message` fields appear
- [ ] Trigger a test alert or wait for the next firing alert to confirm Discord message format