### PR TITLE
fix: set Prometheus externalUrl for correct alert source links

### DIFF
--- a/cluster/observability/kube-prometheus-stack/external-secret-alertmanager-config.yaml
+++ b/cluster/observability/kube-prometheus-stack/external-secret-alertmanager-config.yaml
@@ -49,9 +49,23 @@ spec:
             - name: default
               discord_configs:
                 - webhook_url: '{{ index . "webhook-url" }}'
+                  title: '{{ "{{" }} if eq .Status "firing" {{ "}}" }}🔥 [FIRING:{{ "{{" }} .Alerts.Firing | len {{ "}}" }}]{{ "{{" }} else {{ "}}" }}✅ [RESOLVED]{{ "{{" }} end {{ "}}" }} {{ "{{" }} .GroupLabels.alertname {{ "}}" }}{{ "{{" }} with .GroupLabels.namespace {{ "}}" }} · {{ "{{" }} . {{ "}}" }}{{ "{{" }} end {{ "}}" }}'
+                  message: |
+                    {{ "{{" }} range .Alerts -{{ "}}" }}
+                    **`{{ "{{" }} .Labels.severity | toUpper {{ "}}" }}`**{{ "{{" }} with .Labels.namespace {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}{{ "{{" }} with .Labels.node {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}{{ "{{" }} with .Labels.cnpg_cluster {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} .Annotations.summary {{ "}}" }}
+                    {{ "{{" }} with .Annotations.runbook_url {{ "}}" }}[Runbook]({{ "{{" }} . {{ "}}" }})  {{ "{{" }} end -{{ "}}" }}[Source ↗]({{ "{{" }} .GeneratorURL {{ "}}" }})
+                    {{ "{{" }} end {{ "}}" }}
             - name: critical
               discord_configs:
                 - webhook_url: '{{ index . "critical-webhook-url" }}'
+                  title: '{{ "{{" }} if eq .Status "firing" {{ "}}" }}🚨 [FIRING:{{ "{{" }} .Alerts.Firing | len {{ "}}" }}]{{ "{{" }} else {{ "}}" }}✅ [RESOLVED]{{ "{{" }} end {{ "}}" }} {{ "{{" }} .GroupLabels.alertname {{ "}}" }}{{ "{{" }} with .GroupLabels.namespace {{ "}}" }} · {{ "{{" }} . {{ "}}" }}{{ "{{" }} end {{ "}}" }}'
+                  message: |
+                    {{ "{{" }} range .Alerts -{{ "}}" }}
+                    **`{{ "{{" }} .Labels.severity | toUpper {{ "}}" }}`**{{ "{{" }} with .Labels.namespace {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}{{ "{{" }} with .Labels.node {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}{{ "{{" }} with .Labels.cnpg_cluster {{ "}}" }} · `{{ "{{" }} . {{ "}}" }}`{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} .Annotations.summary {{ "}}" }}
+                    {{ "{{" }} with .Annotations.runbook_url {{ "}}" }}[Runbook]({{ "{{" }} . {{ "}}" }})  {{ "{{" }} end -{{ "}}" }}[Source ↗]({{ "{{" }} .GeneratorURL {{ "}}" }})
+                    {{ "{{" }} end {{ "}}" }}
             - name: deadman
               webhook_configs:
                 - url: '{{ index . "ping-url" }}'

--- a/cluster/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/cluster/observability/kube-prometheus-stack/helmrelease.yaml
@@ -30,6 +30,7 @@ spec:
     # ── Prometheus ────────────────────────────────────────────────────────────
     prometheus:
       prometheusSpec:
+        externalUrl: http://prometheus.internal.wat.sn
         nodeSelector:
           kubernetes.io/arch: amd64
         retention: 14d


### PR DESCRIPTION
## Summary

- Alert `[Source ↗]` links currently point to `http://kube-prometheus-stack-prometheus.observability:9090/...` which is unreachable outside the cluster
- Setting `prometheusSpec.externalUrl` causes Prometheus to embed the ingress hostname in the `generatorURL` of every alert it sends to Alertmanager

## Test plan

- [ ] After Flux reconciles, send a test alert and confirm the Source link uses `http://prometheus.internal.wat.sn`