### PR TITLE
fix: automount service account token for system-upgrade-controller

### DIFF
--- a/cluster/system-upgrade/helmrelease.yaml
+++ b/cluster/system-upgrade/helmrelease.yaml
@@ -31,6 +31,7 @@ spec:
         serviceAccount:
           identifier: system-upgrade-controller
         pod:
+          automountServiceAccountToken: true
           securityContext:
             runAsUser: 65534
             runAsGroup: 65534


### PR DESCRIPTION
## Summary

- Adds `automountServiceAccountToken: true` to the system-upgrade-controller pod spec
- app-template v5 defaults to `false` (changed from v3), which caused the controller to crash on startup with `no configuration has been provided` — it couldn't find its SA token at `/var/run/secrets/kubernetes.io/serviceaccount/token`
- The HelmRelease had been Stalled since the v5 migration (PR #2029 merged 2026-06-15); this resolves the root cause

## Test plan

- [ ] HelmRelease reconciles successfully
- [ ] Pods come up Running (not CrashLoopBackOff)
- [ ] Controller logs show successful API server connection