### PR TITLE
feat: alert on Flux HelmRelease failures

### DIFF
--- a/cluster/flux-system/kustomization.yaml
+++ b/cluster/flux-system/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - gotk-sync.yaml
 - notifications.yaml
 - helm-chart-repos
+- podmonitor-flux-controllers.yaml

--- a/cluster/flux-system/podmonitor-flux-controllers.yaml
+++ b/cluster/flux-system/podmonitor-flux-controllers.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: flux-controllers
+  namespace: flux-system
+spec:
+  namespaceSelector:
+    matchNames:
+      - flux-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: flux
+  podMetricsEndpoints:
+    - port: http-prom
+      path: /metrics

--- a/cluster/observability/kube-prometheus-stack/kustomization.yaml
+++ b/cluster/observability/kube-prometheus-stack/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - helmrelease.yaml
   - ingress.yaml
   - prometheusrule-pvc.yaml
+  - prometheusrule-flux.yaml
 configMapGenerator:
   # CloudNativePG dashboard - grafana.com 20417, pinned to revision 4 (2025-04-14).
   # Update by re-downloading from /api/dashboards/20417/revisions/<rev>/download.

--- a/cluster/observability/kube-prometheus-stack/prometheusrule-flux.yaml
+++ b/cluster/observability/kube-prometheus-stack/prometheusrule-flux.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: flux-helmrelease
+  namespace: observability
+spec:
+  groups:
+    - name: flux.helmrelease.rules
+      rules:
+        - alert: HelmReleaseFailed
+          expr: gotk_reconcile_condition{kind="HelmRelease", type="Ready", status="False"} == 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "HelmRelease {{ $labels.name }} has been failing for 30+ minutes"
+            description: "HelmRelease {{ $labels.name }} in namespace {{ $labels.exported_namespace }} is NotReady. Check: kubectl describe helmrelease {{ $labels.name }} -n {{ $labels.exported_namespace }}"
+            runbook_url: "https://fluxcd.io/flux/components/helm/helmreleases/#troubleshooting"


### PR DESCRIPTION
## What

Adds two new resources to close a monitoring gap where a HelmRelease could be stuck in a failed state for days with no alert firing (identified in the June 2026 cluster audit).

### `cluster/flux-system/podmonitor-flux-controllers.yaml`
A `PodMonitor` that scrapes metrics from all Flux controller pods via the shared `app.kubernetes.io/part-of: flux` label, targeting the `http-prom` (port 8080) container port. This is necessary because the Flux controllers expose metrics only as a container port — there are no metrics-capable Services in `gotk-components.yaml` — making a PodMonitor the correct choice over a ServiceMonitor.

This is the first Flux scrape config in the repo; without it, `gotk_reconcile_condition` is unavailable to Prometheus and the alert below would never fire.

### `cluster/observability/kube-prometheus-stack/prometheusrule-flux.yaml`
A `PrometheusRule` that fires `HelmReleaseFailed` (severity: warning) after any HelmRelease has been in a NotReady state for 30 continuous minutes:

```
gotk_reconcile_condition{kind="HelmRelease", type="Ready", status="False"} == 1
```

The alert annotation includes the `kubectl describe` command needed to investigate, and a link to the Flux troubleshooting guide.

## Why

A HelmRelease was previously stuck/stalled for days with no persistent alert firing. kube-prometheus-stack was already configured with `podMonitorSelectorNilUsesHelmValues: false` and `ruleSelectorNilUsesHelmValues: false`, so both new resources are picked up automatically with no HelmRelease changes required.