### PR TITLE
chore(deps): bump sealed-secrets chart from 2.18.6 to 2.19.0

### DIFF
--- a/cluster/kube-system/sealed-secrets/helmrelease.yaml
+++ b/cluster/kube-system/sealed-secrets/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
   chart:
     spec:
       chart: sealed-secrets
-      version: 2.18.6
+      version: 2.19.0
       sourceRef:
         kind: HelmRepository
         name: sealed-secrets-charts


### PR DESCRIPTION
## Summary

- Bumps sealed-secrets HelmRelease chart version from `2.18.6` (app v0.37.0) to `2.19.0` (app v0.38.1)
- Renovate did not generate this PR automatically (likely due to HelmRepository URL mismatch), so bumping manually

## Test plan

- [ ] Flux reconciles the HelmRelease after merge
- [ ] `sealed-secrets-controller` pod restarts and runs v0.38.1
- [ ] Existing SealedSecrets continue to decrypt successfully