### PR TITLE
feat: enable native ServiceMonitors for Authentik and Immich

### DIFF
--- a/cluster/identity/authentik/helmrelease.yaml
+++ b/cluster/identity/authentik/helmrelease.yaml
@@ -54,6 +54,11 @@ spec:
         accountId: geoipId
         licenseKey: geoipKey
     server:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+          interval: 30s
       ingress:
         enabled: true
         ingressClassName: "nginx"
@@ -67,3 +72,9 @@ spec:
         hosts:
         - auth.internal.wat.sn
         - auth.wat.sn
+    worker:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+          interval: 30s

--- a/cluster/media/immich/helmrelease.yaml
+++ b/cluster/media/immich/helmrelease.yaml
@@ -43,6 +43,8 @@ spec:
               IMMICH_MACHINE_LEARNING_URL: '{{ printf "http://%s-machine-learning:3003" .Release.Name }}'
 
     immich:
+      metrics:
+        enabled: true
       persistence:
         library:
           existingClaim: immich-storage


### PR DESCRIPTION
## Summary

- **Authentik**: enables `server.metrics` and `worker.metrics` in the HelmRelease — the chart creates `authentik-server-metrics` and `authentik-worker-metrics` ClusterIP services on port 9300 and a ServiceMonitor for each in the `identity` namespace
- **Immich**: enables `immich.metrics` in the HelmRelease — the chart creates the metrics service and ServiceMonitor in the `media` namespace automatically
- No standalone manifests or `kustomization.yaml` changes needed; chart-managed lifecycle keeps drift detection clean

kube-prometheus-stack already has `serviceMonitorSelectorNilUsesHelmValues: false`, so both monitors will be scraped automatically once the HelmReleases reconcile.

## Test plan

- [ ] Authentik HelmRelease reconciles cleanly; `kubectl get svc -n identity | grep metrics` shows two new services
- [ ] Immich HelmRelease reconciles cleanly; `kubectl get svc -n media | grep metrics` shows a new metrics service
- [ ] `kubectl get servicemonitor -n identity` shows `authentik-server` and `authentik-worker` monitors
- [ ] `kubectl get servicemonitor -n media` shows an `immich` monitor
- [ ] In Prometheus UI, both targets appear under Status → Targets and are `UP`