### PR TITLE
fix: remove memos-db LoadBalancer to free IP for coredns

### DIFF
--- a/cluster/home/memos/postgres/helmrelease.yaml
+++ b/cluster/home/memos/postgres/helmrelease.yaml
@@ -35,20 +35,6 @@ spec:
         storageClass: "freenas-nfs-csi"
       services:
         disabledDefaultServices: ["ro", "r"]
-        additional:
-          - selectorType: rw
-            serviceTemplate:
-              metadata:
-                name: "memos-db-lb"
-                annotations:
-                  external-dns.alpha.kubernetes.io/hostname: db.memos.internal.wat.sn.
-              spec:
-                type: LoadBalancer
-                ports:
-                  - name: postgres
-                    port: 5432
-                    targetPort: 5432
-                    protocol: TCP
       certificates:
         serverCASecret: memos-db-cert
         serverTLSSecret: memos-db-cert

--- a/cluster/system-upgrade/helmrelease.yaml
+++ b/cluster/system-upgrade/helmrelease.yaml
@@ -31,6 +31,7 @@ spec:
         serviceAccount:
           identifier: system-upgrade-controller
         pod:
+          automountServiceAccountToken: true
           securityContext:
             runAsUser: 65534
             runAsGroup: 65534


### PR DESCRIPTION
## Summary

- Removes the `memos-db-lb` LoadBalancer service from the memos CNPG cluster spec
- This frees `192.168.0.0` (previously held by memos-db-lb) so MetalLB can assign it to coredns-primary
- coredns-primary has `192.168.0.0` hardcoded as its LoadBalancer IP but was blocked by this conflict after klipper servicelb was disabled

## Test plan

- [ ] After merge and Flux reconcile, `kubectl get svc memos-db-lb -n memos` returns NotFound
- [ ] `kubectl get svc coredns-primary -n network` shows EXTERNAL-IP `192.168.0.0`
- [ ] DNS resolution via `192.168.0.0` works for internal zones