### PR TITLE
fix: restore memos-db LoadBalancer with dedicated IP

### DIFF
--- a/cluster/home/memos/postgres/helmrelease.yaml
+++ b/cluster/home/memos/postgres/helmrelease.yaml
@@ -35,6 +35,21 @@ spec:
         storageClass: "freenas-nfs-csi"
       services:
         disabledDefaultServices: ["ro", "r"]
+        additional:
+          - selectorType: rw
+            serviceTemplate:
+              metadata:
+                name: "memos-db-lb"
+                annotations:
+                  external-dns.alpha.kubernetes.io/hostname: db.memos.internal.wat.sn.
+              spec:
+                type: LoadBalancer
+                loadBalancerIP: 192.168.0.6
+                ports:
+                  - name: postgres
+                    port: 5432
+                    targetPort: 5432
+                    protocol: TCP
       certificates:
         serverCASecret: memos-db-cert
         serverTLSSecret: memos-db-cert


### PR DESCRIPTION
Restores memos-db-lb LoadBalancer with a fixed IP to avoid future MetalLB allocation conflicts.

## Test plan

- [ ]`kubectl get svc memos-db-lb -n memos` shows EXTERNAL-IP `192.168.0.6`