### PR TITLE
Add wildcard Certificate for the Traefik Gateway

### DIFF
--- a/cluster/network/kustomization.yaml
+++ b/cluster/network/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - gateway-api
   - ingress-nginx
   - metallb
+  - traefik

--- a/cluster/network/traefik/certificate.yaml
+++ b/cluster/network/traefik/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-wat-sn-tls
+spec:
+  secretName: wildcard-wat-sn-tls
+  dnsNames:
+    - "*.wat.sn"
+    - "*.internal.wat.sn"
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/cluster/network/traefik/kustomization.yaml
+++ b/cluster/network/traefik/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - certificate.yaml


### PR DESCRIPTION
## Summary
- Second step of the ingress-nginx → Traefik (Gateway API) migration.
- Adds a single wildcard `Certificate` (`*.wat.sn`, `*.internal.wat.sn`) via the existing `letsencrypt-prod` ClusterIssuer (DNS-01, same mechanism every existing per-app cert already uses). Traefik's Gateway will reference this one secret directly for TLS instead of each app carrying its own dedicated cert.
- Needs to land before the Traefik HelmRelease PR, since its chart-managed Gateway listener references this secret by name.

## Test plan
- [ ] `kubectl describe certificate -n network wildcard-wat-sn-tls` shows `Ready: True` after the DNS-01 challenge completes