### PR TITLE
Fix missing namespace on wildcard Certificate

### DIFF
--- a/cluster/network/kustomization.yaml
+++ b/cluster/network/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: network
 resources:
   - namespace.yaml
   - cloudflared

--- a/cluster/network/traefik/certificate.yaml
+++ b/cluster/network/traefik/certificate.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: wildcard-wat-sn-tls
+  namespace: network
 spec:
   secretName: wildcard-wat-sn-tls
   dnsNames:


### PR DESCRIPTION
## Summary
- Hotfix for #2106: the `Certificate` was missing `metadata.namespace: network`, which is currently blocking the whole `flux-system` Kustomization from reconciling cluster-wide (`Certificate/wildcard-wat-sn-tls namespace not specified`).
- `cluster/network/` sets `metadata.namespace` explicitly per-resource rather than via a Kustomize `namespace:` transformer — missed that convention.

## Test plan
- [ ] `flux get kustomization flux-system` shows `Ready: True` again after merge
- [ ] `kubectl describe certificate -n network wildcard-wat-sn-tls` shows `Ready: True` once the DNS-01 challenge completes