### PR TITLE
Add Traefik with Gateway API provider enabled

### DIFF
--- a/cluster/flux-system/helm-chart-repos/kustomization.yaml
+++ b/cluster/flux-system/helm-chart-repos/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - planka.yaml
   - renovate.yaml
   - sealed-secrets.yaml
+  - traefik.yaml

--- a/cluster/flux-system/helm-chart-repos/traefik.yaml
+++ b/cluster/flux-system/helm-chart-repos/traefik.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: traefik-charts
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://traefik.github.io/charts
+  timeout: 3m

--- a/cluster/network/traefik/helmrelease.yaml
+++ b/cluster/network/traefik/helmrelease.yaml
@@ -1,0 +1,43 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: traefik
+  namespace: network
+spec:
+  driftDetection:
+    mode: enabled
+  interval: 30m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+  chart:
+    spec:
+      chart: traefik
+      version: 41.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik-charts
+        namespace: flux-system
+      interval: 10m
+  values:
+    providers:
+      kubernetesIngress:
+        enabled: false
+      kubernetesGateway:
+        enabled: true
+    gateway:
+      listeners:
+        web:
+          namespacePolicy:
+            from: All
+        websecure:
+          port: 8443
+          protocol: HTTPS
+          namespacePolicy:
+            from: All
+          certificateRefs:
+            - name: wildcard-wat-sn-tls

--- a/cluster/network/traefik/kustomization.yaml
+++ b/cluster/network/traefik/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - certificate.yaml
+  - helmrelease.yaml


### PR DESCRIPTION
## Summary
- Third step of the ingress-nginx → Traefik (Gateway API) migration.
- New Traefik HelmRelease (chart 41.2.0 / appVersion v3.7.10) with `providers.kubernetesGateway.enabled: true` and `providers.kubernetesIngress.enabled: false` — ingress-nginx keeps handling all existing `Ingress` objects untouched, Traefik only handles Gateway API resources.
- The chart auto-creates a `GatewayClass` (named `traefik`) and a default `Gateway`. The `websecure` listener (443) is wired to the wildcard `Certificate` from #2106/#2107. Both listeners set `namespacePolicy.from: All` so `HTTPRoute`s from other namespaces (media, home, identity, etc.) can attach — Gateway API restricts cross-namespace route attachment by default.

## Test plan
- [ ] `flux get helmrelease -n network traefik` shows `Ready`
- [ ] `kubectl get gatewayclass,gateway -n network` shows the `traefik` GatewayClass and Gateway both `Accepted`/`Programmed`
- [ ] No impact to ingress-nginx or any existing app — all still reachable