### PR TITLE
external-dns: recognize Gateway API HTTPRoutes

### DIFF
--- a/cluster/network/external-dns/helmrelease.yaml
+++ b/cluster/network/external-dns/helmrelease.yaml
@@ -33,6 +33,7 @@ spec:
     sources:
       - service
       - ingress
+      - gateway-httproute
       - crd
     policy: upsert-only
     interval: 1m


### PR DESCRIPTION
## Summary
- Fourth step of the ingress-nginx → Traefik (Gateway API) migration.
- Adds `gateway-httproute` to external-dns's `sources` so it starts creating/updating DNS A records for `HTTPRoute` resources, alongside the existing `service`/`ingress`/`crd` sources. Needed before migrating any app, since jellyfin's `watch.internal.wat.sn` record needs to move from ingress-nginx's IP to Traefik's once it switches from Ingress to HTTPRoute.

## Test plan
- [ ] `flux get helmrelease -n network external-dns` shows `Ready`
- [ ] No existing DNS records change (no apps have migrated yet, so this is additive only)