### PR TITLE
Migrate jellyfin from Ingress to HTTPRoute (Gateway API pilot)

### DIFF
--- a/cluster/media/jellyfin/helmrelease.yaml
+++ b/cluster/media/jellyfin/helmrelease.yaml
@@ -55,22 +55,15 @@ spec:
         ports:
           http:
             port: 8096
-    ingress:
+    route:
       main:
-        className: nginx
-        annotations:
-          cert-manager.io/cluster-issuer: "letsencrypt-prod"
-        hosts:
-          - host: watch.internal.wat.sn
-            paths:
-              - path: /
-                service:
-                  identifier: main
-                  port: http
-        tls:
-          - hosts:
-              - watch.internal.wat.sn
-            secretName: jellyfin-ingress-cert
+        kind: HTTPRoute
+        hostnames:
+          - watch.internal.wat.sn
+        parentRefs:
+          - name: traefik-gateway
+            namespace: network
+            sectionName: websecure
     persistence:
       config:
         existingClaim: jellyfin-config


### PR DESCRIPTION
## Summary
- Fifth and final step of this round of the ingress-nginx → Traefik (Gateway API) migration — the pilot app.
- Jellyfin chosen because it's internal-only (`watch.internal.wat.sn`, not routed through the public Cloudflare tunnel) and has no nginx-specific annotations — lowest blast radius.
- Replaces the `ingress` key with a `route` key (app-template v5's native Gateway API support). Attaches only to the Gateway's `websecure` listener (TLS via the wildcard cert from #2106/#2107) — no plain-HTTP fallback.
- `external-dns` will automatically move the `watch.internal.wat.sn` A record from ingress-nginx's IP to Traefik's (`192.168.0.2`) once this merges, since it now watches Gateway API `HTTPRoute`s (#2109). No manual DNS work needed.
- ingress-nginx and every other app's `Ingress` are completely untouched — this only affects jellyfin.
- Verified locally: rendered this exact `values:` block against the pinned `app-template@5.0.1` chart with `helm template` — produces a correct `HTTPRoute` with `parentRefs`/`hostnames` as expected and the `rules.backendRefs` auto-resolving to the `jellyfin` Service on port 8096.

## Test plan
- [ ] `kubectl get httproute -n media jellyfin` shows `Accepted`/`ResolvedRefs` True
- [ ] `dig watch.internal.wat.sn` resolves to `192.168.0.2` (Traefik), not ingress-nginx's IP
- [ ] `https://watch.internal.wat.sn` loads Jellyfin with a valid TLS cert
- [ ] Jellyfin's separate `media.internal.wat.sn` LoadBalancer Service (unrelated to this change) still works