### PR TITLE
Migrate home-assistant, mealie, onepassword-connect to HTTPRoute

### DIFF
--- a/cluster/external-secrets/stores/1password/helmrelease.yaml
+++ b/cluster/external-secrets/stores/1password/helmrelease.yaml
@@ -59,22 +59,15 @@ spec:
         ports:
           http:
             port: *apiPort
-    ingress:
+    route:
       api:
-        className: nginx
-        annotations:
-          cert-manager.io/cluster-issuer: "letsencrypt-prod"
-        hosts:
-          - host: &host "1pconnect.internal.wat.sn"
-            paths:
-              - path: /
-                service:
-                  identifier: api
-                  port: http
-        tls:
-          - hosts:
-              - *host
-            secretName: 1password-connect-ingress-cert
+        kind: HTTPRoute
+        hostnames:
+          - 1pconnect.internal.wat.sn
+        parentRefs:
+          - name: traefik-gateway
+            namespace: network
+            sectionName: websecure
     persistence:
       shared:
         type: emptyDir

--- a/cluster/home/homeassistant/helmrelease.yaml
+++ b/cluster/home/homeassistant/helmrelease.yaml
@@ -60,44 +60,32 @@ spec:
           code-server:
             port: 8080
 
-    ingress:
+    route:
       app:
-        className: nginx
-        annotations:
-          cert-manager.io/cluster-issuer: "letsencrypt-prod"
-        hosts:
-          - host: &ihost "ha.internal.wat.sn"
-            paths:
-              - path: /
-                service:
-                  identifier: app
-                  port: http
-          - host: &host "ha.wat.sn"
-            paths:
-              - path: /
-                service:
-                  identifier: app
-                  port: http
-        tls:
-          - hosts:
-              - *host
-              - *ihost
-            secretName: home-assistant-cert
+        kind: HTTPRoute
+        hostnames:
+          - ha.internal.wat.sn
+          - ha.wat.sn
+        parentRefs:
+          - name: traefik-gateway
+            namespace: network
+            sectionName: websecure
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8123
       code:
-        className: nginx
-        annotations:
-          cert-manager.io/cluster-issuer: "letsencrypt-prod"
-        hosts:
-          - host: &codeihost "ha-code.internal.wat.sn"
-            paths:
-              - path: /
-                service:
-                  identifier: app
-                  port: code-server
-        tls:
-          - hosts:
-              - *codeihost
-            secretName: home-assistant-code-cert
+        kind: HTTPRoute
+        hostnames:
+          - ha-code.internal.wat.sn
+        parentRefs:
+          - name: traefik-gateway
+            namespace: network
+            sectionName: websecure
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8080
     persistence:
       config:
         existingClaim: home-assistant-config

--- a/cluster/home/mealie/app/helmrelease.yaml
+++ b/cluster/home/mealie/app/helmrelease.yaml
@@ -72,29 +72,16 @@ spec:
           http:
             port: 9000
 
-    ingress:
+    route:
       main:
-        annotations:
-          cert-manager.io/cluster-issuer: "letsencrypt-prod"
-        className: "nginx"
-        hosts:
-          - host: &ihost "mealie.internal.wat.sn"
-            paths:
-              - path: /
-                service:
-                  identifier: main
-                  port: http
-          - host: &host mealie.wat.sn
-            paths:
-              - path: /
-                service:
-                  identifier: main
-                  port: http
-        tls:
-          - hosts:
-              - *host
-              - *ihost
-            secretName: mealie-ingress-cert
+        kind: HTTPRoute
+        hostnames:
+          - mealie.internal.wat.sn
+          - mealie.wat.sn
+        parentRefs:
+          - name: traefik-gateway
+            namespace: network
+            sectionName: websecure
 
     persistence:
       config:


### PR DESCRIPTION
## Summary
- Batch migration of 3 simple app-template apps from ingress-nginx to Traefik (Gateway API), same pattern as jellyfin (#2110). None use nginx-specific annotations, so all just swap `ingress:` for `route:`.
- `home-assistant` has two routes since its single Service exposes two ports (main app on 8123, code-server on 8080) — used explicit `rules.backendRefs` for both instead of relying on default-to-primary-service.
- `mealie` and `onepassword-connect` use the chart's default rule behavior (single port, auto-resolves to the primary Service).
- ingress-nginx and every other unmigrated app are untouched.

## Test plan
- [ ] `kubectl get httproute -n home-assistant,mealie,external-secrets` all show `Accepted`/`ResolvedRefs` True
- [ ] Verified locally: rendered all three `values:` blocks via `helm template` against the pinned `app-template@5.0.1` chart — correct HTTPRoutes generated, correct ports resolved
- [ ] `ha.wat.sn`/`ha.internal.wat.sn`, `ha-code.internal.wat.sn`, `mealie.wat.sn`/`mealie.internal.wat.sn`, `1pconnect.internal.wat.sn` all resolve to Traefik's IP (`192.168.0.2`) and serve valid TLS after merge