### PR TITLE
Migrate memos, immich to HTTPRoute

### DIFF
--- a/cluster/home/memos/app/helmrelease.yaml
+++ b/cluster/home/memos/app/helmrelease.yaml
@@ -48,31 +48,16 @@ spec:
         ports:
           http:
             port: *apiPort
-    ingress:
+    route:
       main:
-        className: nginx
-        annotations:
-          # proxy-body-size is set to 0 to remove the body limit on file uploads
-          nginx.ingress.kubernetes.io/proxy-body-size: "0"
-          cert-manager.io/cluster-issuer: "letsencrypt-prod"
-        hosts:
-          - host: &ihost "memos.internal.wat.sn"
-            paths:
-              - path: /
-                service:
-                  identifier: main
-                  port: http
-          - host: &host "memos.wat.sn"
-            paths:
-              - path: /
-                service:
-                  identifier: main
-                  port: http
-        tls:
-          - hosts:
-              - *host
-              - *ihost
-            secretName: memos-cert
+        kind: HTTPRoute
+        hostnames:
+          - memos.internal.wat.sn
+          - memos.wat.sn
+        parentRefs:
+          - name: traefik-gateway
+            namespace: network
+            sectionName: websecure
     persistence:
       resources:
         existingClaim: memos-resources

--- a/cluster/media/immich/helmrelease.yaml
+++ b/cluster/media/immich/helmrelease.yaml
@@ -62,29 +62,16 @@ spec:
                 repository: ghcr.io/immich-app/immich-server
                 pullPolicy: IfNotPresent
                 tag: v2.7.5@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5
-      ingress:
+      route:
         main:
-          enabled: true
-          className: "nginx"
-          annotations:
-            nginx.ingress.kubernetes.io/proxy-body-size: "0"
-            cert-manager.io/cluster-issuer: "letsencrypt-prod"
-          hosts:
-            - host: photos.internal.wat.sn
-              paths:
-                - path: "/"
-                  service:
-                    identifier: main
-            - host: photos.wat.sn
-              paths:
-                - path: "/"
-                  service:
-                    identifier: main
-          tls:
-            - hosts:
-                - photos.internal.wat.sn
-                - photos.corywatson.net
-              secretName: immich-ingress-cert
+          kind: HTTPRoute
+          hostnames:
+            - photos.internal.wat.sn
+            - photos.wat.sn
+          parentRefs:
+            - name: traefik-gateway
+              namespace: network
+              sectionName: websecure
 
     machine-learning:
       enabled: true


### PR DESCRIPTION
## Summary
- Batch 2 of the ingress-nginx → Traefik migration (after #2110, #2111).
- Both apps previously used `nginx.ingress.kubernetes.io/proxy-body-size: "0"` to disable nginx's default upload-size cap. Traefik has no equivalent default cap — its `buffering` middleware (which is what imposes `maxRequestBodyBytes`) is entirely opt-in and we're not attaching one, so plain `route:` already matches the old "unlimited" behavior. No Middleware resource needed.
- Also fixes a pre-existing bug as a side effect: immich's old `tls.hosts` (`photos.corywatson.net`) didn't match its actual rule hosts (`photos.wat.sn`) — moot now since TLS comes from the shared wildcard Gateway cert, not a per-app `tls:` block.
- immich uses its own upstream chart, not app-template directly, but that chart depends on the exact same `bjw-s common@5.0.1` library, so `server.route` works identically.

## Test plan
- [ ] `kubectl get httproute -n home,media memos immich-server` show `Accepted`/`ResolvedRefs` True
- [ ] Verified locally: rendered both `values:` blocks via `helm template` against the pinned chart versions (`app-template@5.0.1`, `immich@0.12.0`) — correct HTTPRoutes generated
- [ ] Large file upload to memos/immich still works post-merge (no body-size regression)