### PR TITLE
Migrate authentik, planka to Gateway API

### DIFF
--- a/cluster/home/planka/helmrelease.yaml
+++ b/cluster/home/planka/helmrelease.yaml
@@ -39,26 +39,6 @@ spec:
       enabled: true
       existingClaim: planka-data
 
-    ingress:
-      enabled: true
-      className: "nginx"
-      annotations:
-         cert-manager.io/cluster-issuer: letsencrypt-prod
-      hosts:
-        - host: &appHost planka.wat.sn
-          paths:
-            - path: /
-              pathType: ImplementationSpecific
-        - host: &appHostInternal planka.internal.wat.sn
-          paths:
-            - path: /
-              pathType: ImplementationSpecific
-      tls:
-      - secretName: planka-cert
-        hosts:
-        - *appHost
-        - *appHostInternal
-
     postgresql:
       enabled: false
 

--- a/cluster/home/planka/httproute.yaml
+++ b/cluster/home/planka/httproute.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: planka
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: network
+      sectionName: websecure
+  hostnames:
+    - planka.wat.sn
+    - planka.internal.wat.sn
+  rules:
+    - backendRefs:
+        - name: planka
+          port: 1337

--- a/cluster/home/planka/kustomization.yaml
+++ b/cluster/home/planka/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
 - helmrelease.yaml
 - external-secret.yaml
 - pvc.yaml
+- httproute.yaml
 - postgres/helmrelease.yaml

--- a/cluster/identity/authentik/helmrelease.yaml
+++ b/cluster/identity/authentik/helmrelease.yaml
@@ -59,19 +59,16 @@ spec:
         serviceMonitor:
           enabled: true
           interval: 30s
-      ingress:
-        enabled: true
-        ingressClassName: "nginx"
-        tls:
-          - hosts:
+      route:
+        main:
+          enabled: true
+          hostnames:
             - auth.internal.wat.sn
             - auth.wat.sn
-            secretName: auth-cert
-        annotations:
-          cert-manager.io/cluster-issuer: letsencrypt-prod
-        hosts:
-        - auth.internal.wat.sn
-        - auth.wat.sn
+          parentRefs:
+            - name: traefik-gateway
+              namespace: network
+              sectionName: websecure
     worker:
       metrics:
         enabled: true


### PR DESCRIPTION
## Summary
- Batch 3 of the ingress-nginx → Traefik migration (after #2110, #2111, #2112). These two use their own upstream charts rather than the bjw-s common library, so needed individual handling instead of the mechanical `ingress:`→`route:` swap.
- **authentik**: the official chart (already pinned at `2026.5.3`, no version bump needed) has native `HTTPRoute` support via `server.route` — swapped the same way as the app-template apps.
- **planka**: checked every available chart version up to the latest `2.2.0` — none add Gateway API support, still `ingress.yaml`-only. Added a standalone `HTTPRoute` (`cluster/home/planka/httproute.yaml`) pointing directly at the chart's own `planka` Service (port 1337) instead, and removed the now-redundant `ingress:` block from its values.
- ingress-nginx and every unmigrated app are untouched. This is the identity provider (authentik/SSO) so extra care taken: rendered locally via `helm template` before pushing (stubbed the `valuesFrom`-injected secret fields, which don't affect route rendering) and confirmed planka's exact Service name/port with a separate local render rather than assuming.

## Test plan
- [ ] `kubectl get httproute -n identity,planka authentik-server planka` show `Accepted`/`ResolvedRefs` True
- [ ] `auth.wat.sn`/`auth.internal.wat.sn` and `planka.wat.sn`/`planka.internal.wat.sn` resolve to Traefik's IP and serve valid TLS
- [ ] SSO login flow through authentik still works for dependent apps (planka OIDC, etc.)